### PR TITLE
fix: deterministic category ordering

### DIFF
--- a/generate_aos_mappings.py
+++ b/generate_aos_mappings.py
@@ -96,7 +96,8 @@ def generate_files(cmd_list, bin_list, categories):
     with open('category_defs.h', 'w') as f:
         f.write('// Auto-generated category IDs\n')
         f.write('#ifndef CATEGORY_DEFS_H\n#define CATEGORY_DEFS_H\n\n')
-        for name, cid in categories.items():
+        # Write categories in deterministic order
+        for name, cid in sorted(categories.items()):
             macro = name.upper().replace(' ', '_')
             f.write(f'#define CAT_{macro}  0x{cid:X}\n')
         f.write('\n#endif\n')


### PR DESCRIPTION
## Summary
- ensure generator writes categories in sorted order for reproducible builds

## Testing
- `python3 generate_aos_mappings.py`
- `make host`
- `make bare`
- `make run` *(fails: qemu missing)*
- `./build/host_test <<'EOF'
HELLO
BYE
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68456cc65bb48325ab54c3a1a8d4f74e