### PR TITLE
Fix CI run command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Build bare metal
         run: make bare
       - name: Run under QEMU
-        run: make run RUN_OPTS="-nographic -serial stdio"
+        run: make run RUN_OPTS="-nographic"
       - name: Check serial output
         run: |
-          make run -nographic -serial stdio | tee output.log
+          make run RUN_OPTS="-nographic" | tee output.log
           grep -q "Kernel started" output.log


### PR DESCRIPTION
## Summary
- update CI workflow to invoke QEMU with `RUN_OPTS="-nographic"`

## Testing
- `python3 generate_aos_mappings.py`
- `make clean`
- `make host`
- `make bare`
- `timeout 5 make -- run RUN_OPTS="-nographic"`

------
https://chatgpt.com/codex/tasks/task_e_684582cc00c8832582076eff9b368e89