### PR TITLE
refine: subsystem parity, error handling, demos, UEFI boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clean:
 memory:
 	@echo "→ Building memory demo"
 	@mkdir -p build
-	gcc -Isubsystems/memory subsystems/memory/memory.c examples/memory_demo.c -o build/memory_demo
+	gcc -Isubsystems/memory subsystems/memory/memory.c src/memory.c examples/memory_demo.c -o build/memory_demo
 
 fs:
 	@echo "→ Building fs demo"

--- a/bare_metal_os/Makefile
+++ b/bare_metal_os/Makefile
@@ -9,9 +9,11 @@ LDFLAGS = -T kernel.ld -m elf_i386 -z separate-code
 
 all: bootloader.bin aos.bin
 
-kernel.bin: kernel.c
-		$(CC) $(CFLAGS) -c $< -o kernel.o
-		$(LD) $(LDFLAGS) kernel.o -o kernel.elf
+kernel.bin: kernel.c memory.c fs.c
+	        $(CC) $(CFLAGS) -c kernel.c -o kernel.o
+	        $(CC) $(CFLAGS) -c memory.c -o memory.o
+	        $(CC) $(CFLAGS) -c fs.c -o fs.o
+	        $(LD) $(LDFLAGS) kernel.o memory.o fs.o -o kernel.elf
 		objcopy -O binary kernel.elf kernel.bin
 
 bootloader.bin: bootloader.asm kernel.bin

--- a/bare_metal_os/fs.c
+++ b/bare_metal_os/fs.c
@@ -1,0 +1,76 @@
+#include "../subsystems/fs/fs.h"
+#include <string.h>
+#include <stddef.h>
+
+#define MAX_FILES 16
+#define MAX_NAME 32
+#define MAX_CONTENT 256
+
+typedef struct {
+    char name[MAX_NAME];
+    char content[MAX_CONTENT];
+    size_t size;
+    size_t pos;
+    int used;
+    int open;
+} File;
+
+static File files[MAX_FILES];
+
+void fs_init(void) {
+    memset(files, 0, sizeof(files));
+}
+
+static File *find_file(const char *name) {
+    for (int i=0;i<MAX_FILES;i++)
+        if (files[i].used && strcmp(files[i].name, name)==0)
+            return &files[i];
+    return NULL;
+}
+
+int fs_open(const char *name, const char *mode) {
+    File *f = find_file(name);
+    if (!f) {
+        for (int i=0;i<MAX_FILES;i++)
+            if (!files[i].used) { f=&files[i]; break; }
+        if (!f) return -1;
+        memset(f,0,sizeof(File));
+        strncpy(f->name,name,MAX_NAME-1);
+        f->used=1;
+    }
+    f->pos=0;
+    f->open=1;
+    if (mode && mode[0]=='w') f->size=0;
+    return (int)(f - files);
+}
+
+size_t fs_read(int fd, char *buf, size_t n) {
+    if (fd<0 || fd>=MAX_FILES) return 0;
+    File *f=&files[fd];
+    if (!f->open) return 0;
+    size_t remain=f->size - f->pos;
+    if (n>remain) n=remain;
+    memcpy(buf, f->content + f->pos, n);
+    f->pos += n;
+    return n;
+}
+
+size_t fs_write(int fd, const char *buf, size_t n) {
+    if (fd<0 || fd>=MAX_FILES) return 0;
+    File *f=&files[fd];
+    if (!f->open) return 0;
+    if (f->pos + n > MAX_CONTENT) n = MAX_CONTENT - f->pos;
+    memcpy(f->content + f->pos, buf, n);
+    f->pos += n;
+    if (f->pos > f->size) f->size = f->pos;
+    return n;
+}
+
+void fs_close(int fd) {
+    if (fd<0 || fd>=MAX_FILES) return;
+    files[fd].open=0;
+}
+
+void fs_ls(void) {
+    (void)0; /* No console on bare metal */
+}

--- a/bare_metal_os/memory.c
+++ b/bare_metal_os/memory.c
@@ -15,3 +15,7 @@ void *mem_alloc(size_t size) {
 void mem_free(void *p) {
     memory_free(p);
 }
+
+void mem_reset(void) {
+    memory_reset();
+}

--- a/examples/memory_demo.c
+++ b/examples/memory_demo.c
@@ -1,15 +1,21 @@
 #include <stdio.h>
 #include "memory.h"
 
-static unsigned char pool[1024];
+/* deliberately small pool to trigger OOM */
+static unsigned char pool[128];
 
 int main(void) {
     memory_init(pool, sizeof(pool));
     void *a = memory_alloc(64);
-    void *b = memory_alloc(128);
-    printf("a=%p b=%p\n", a, b);
-    memory_free(b);
+    printf("a=%p\n", a);
+    /* this allocation should fail and return NULL */
+    void *b = memory_alloc(80);
+    printf("b=%p (expected NULL)\n", b);
+    /* invalid free to test error logging */
+    memory_free((void*)0xdeadbeef);
+    /* reset and allocate again */
+    mem_reset();
     void *c = memory_alloc(32);
-    printf("c=%p (reused)\n", c);
+    printf("c=%p after reset\n", c);
     return 0;
 }

--- a/examples/memory_demo.sh
+++ b/examples/memory_demo.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Demo for memory subsystem with error cases
+set -e
+> AOS-CHECKLIST.log
+out=$(./build/memory_demo)
+echo "$out"
+echo "--- log ---"
+cat AOS-CHECKLIST.log
+echo "$out" | grep -q "expected NULL"
+grep -q "Out of memory" AOS-CHECKLIST.log
+grep -q "invalid pointer" AOS-CHECKLIST.log

--- a/examples/plugin_demo.c
+++ b/examples/plugin_demo.c
@@ -1,7 +1,11 @@
 #include "plugin.h"
+#include <stdio.h>
 int main(void){
     plugin_install("local");
     plugin_load("sample");
+    /* attempt to load a missing plugin to trigger error */
+    if (plugin_load("missing") != 0)
+        printf("missing plugin handled\n");
     plugin_list();
     return 0;
 }

--- a/examples/plugin_demo.sh
+++ b/examples/plugin_demo.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-# Demo for plugin loader
-./build/plugin_demo
+# Demo for plugin loader with error check
+set -e
+out=$(./build/plugin_demo 2>&1)
+echo "$out"
+echo "$out" | grep -q "missing plugin handled"

--- a/examples/policy_demo.c
+++ b/examples/policy_demo.c
@@ -3,5 +3,8 @@
 int main(void){
     policy_load("allow-all");
     if(policy_check("test")) printf("allowed\n");
+    /* load deny rule and verify blocking */
+    policy_load("deny test");
+    if(!policy_check("test")) printf("denied\n");
     return 0;
 }

--- a/examples/policy_demo.sh
+++ b/examples/policy_demo.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
-# Demo for policy engine
-./build/policy_demo
+# Demo for policy engine with deny rule
+set -e
+> AOS-CHECKLIST.log
+out=$(./build/policy_demo)
+echo "$out"
+echo "$out" | grep -q "allowed"
+echo "$out" | grep -q "denied"
+grep -q "policy deny" AOS-CHECKLIST.log

--- a/src/memory.c
+++ b/src/memory.c
@@ -21,3 +21,8 @@ void mem_free(void *p) {
     memory_host_init();
     memory_free(p);
 }
+
+void mem_reset(void) {
+    memory_host_init();
+    memory_reset();
+}

--- a/src/policy.c
+++ b/src/policy.c
@@ -1,14 +1,22 @@
 #include "policy.h"
 #include <stdio.h>
+#include <string.h>
 
-static const char *policy;
+static char deny_action[32];
 
 void policy_load(const char *script) {
-    policy = script;
+    deny_action[0] = '\0';
+    if (script && strncmp(script, "deny ", 5) == 0) {
+        strncpy(deny_action, script + 5, sizeof(deny_action) - 1);
+    }
     printf("policy loaded: %s\n", script ? script : "");
 }
 
 int policy_check(const char *action) {
-    (void)action;
+    if (deny_action[0] && action && strcmp(action, deny_action) == 0) {
+        FILE *f = fopen("AOS-CHECKLIST.log", "a");
+        if (f) { fprintf(f, "policy deny %s\n", action); fclose(f); }
+        return 0;
+    }
     return 1;
 }

--- a/subsystems/memory/memory.h
+++ b/subsystems/memory/memory.h
@@ -10,5 +10,6 @@ void memory_reset(void);
 /* convenience wrappers for host/bare usage */
 void *mem_alloc(size_t size);
 void mem_free(void *ptr);
+void mem_reset(void);
 
 #endif


### PR DESCRIPTION
## Summary
- add mem_reset on bare metal and update memory demo to check error paths
- extend plugin and policy demos with simple failure tests
- implement basic deny rule in policy engine
- adjust Makefile memory target to link host wrappers

## Testing
- `python3 generate_aos_mappings.py`
- `make clean`
- `make host`
- `make memory`
- `./examples/memory_demo.sh`
- `make fs`
- `./build/fs_demo`
- `make ai`
- `echo "test" | ./build/ai_demo`
- `make branch`
- `./build/branch_demo`
- `make branch-vm`
- `./build/branch_vm_demo`
- `make branch-net`
- `./build/branch_fed_demo --port 9999 & pid=$!; sleep 1; ./build/branch_fed_demo --peer 127.0.0.1:9999 --sync && kill $pid`
- `make plugins`
- `./examples/plugin_demo.sh`
- `make policy`
- `./examples/policy_demo.sh`
- `make iso`
- `make ui-check`


------
https://chatgpt.com/codex/tasks/task_e_6846476ab8608325a05ac9041084fcbc