### PR TITLE
Add plugin hot-swap loader

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -30,7 +30,6 @@ Initial repository had no AGENT log. PATCHLOG.md notes prior work on branch CLI 
 - Fixed branch graph orientation bug. Clone now links parent->child for tree output.
 - Updated load_state to rebuild symmetric adjacency matrix.
 - Verified `branch tree` prints hierarchy correctly.
-UNRESOLVED: unknown command
 ## [2025-06-09 06:06 UTC] — meta sweep: repo agent-memory update
 by: codex
 - Introduced time-stamped log format and baton-pass comments across core subsystems.
@@ -39,4 +38,12 @@ by: codex
 
 Next agent must:
 - Follow the same log and comment style for all future updates.
-- Resolve the earlier UNRESOLVED entry about "unknown command" in REPL.
+- Review plugin sandboxing and security.
+
+## [2025-06-09 06:18 UTC] — plugin hot-swap MVP
+by: codex
+- Implemented plugin_unload and extended plugin interface with init/exec/cleanup.
+- Added REPL `plugin` commands supporting load/unload/list.
+- Updated sample plugin and demo to exercise unload logic.
+- Resolved UNRESOLVED entry by recognizing plugin commands in REPL.
+- Open issue: plugin path validation and sandboxing remain.

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ branch-vm:
 	@mkdir -p build
 	gcc -Iinclude src/branch_vm.c subsystems/branch/branch.c examples/branch_vm_demo.c -o build/branch_vm_demo
 
-	plugins:
+plugins:
 	@echo "→ Building plugins demo"
 	@mkdir -p build/plugins
 	gcc -fPIC -shared -o build/plugins/sample.so examples/sample_plugin.c

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -39,3 +39,14 @@ by: codex
 
 Next agent must:
 - Ensure all future patches maintain this style and expand documentation.
+
+## [2025-06-09 06:18 UTC] — plugin hot-swap MVP
+by: codex
+### Changes
+- Added plugin_unload implementation and plugin_exec API.
+- Extended REPL with `plugin` command.
+- Updated sample plugin and demo for full lifecycle.
+### Tests
+- `make host`
+- `make plugins`
+- `./examples/plugin_demo.sh`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ make plugins
 ./examples/plugin_demo.sh
 ```
 
-Loads a sample plugin built as a shared object.
+Loads and then unloads a sample plugin built as a shared object.
 
 ## Real Hardware Boot
 

--- a/examples/plugin_demo.c
+++ b/examples/plugin_demo.c
@@ -7,5 +7,7 @@ int main(void){
     if (plugin_load("missing") != 0)
         printf("missing plugin handled\n");
     plugin_list();
+    plugin_unload("sample");
+    plugin_list();
     return 0;
 }

--- a/examples/plugin_demo.sh
+++ b/examples/plugin_demo.sh
@@ -4,3 +4,4 @@ set -e
 out=$(./build/plugin_demo 2>&1)
 echo "$out"
 echo "$out" | grep -q "missing plugin handled"
+echo "$out" | grep -q "Unloaded sample"

--- a/examples/sample_plugin.c
+++ b/examples/sample_plugin.c
@@ -1,4 +1,14 @@
 #include <stdio.h>
-void plugin_entry(void) {
+
+int plugin_init(void) {
+    printf("sample plugin init\n");
+    return 0;
+}
+
+void plugin_exec(void) {
     printf("sample plugin executed\n");
+}
+
+void plugin_cleanup(void) {
+    printf("sample plugin cleanup\n");
 }

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -30,6 +30,7 @@ void cmd_br_vm_stop_wrapper(int argc, char **argv);
 void cmd_plugin_install_wrapper(int argc, char **argv);
 void cmd_plugin_list_wrapper(int argc, char **argv);
 void cmd_plugin_load_wrapper(int argc, char **argv);
+void cmd_plugin_unload_wrapper(int argc, char **argv);
 void cmd_br_peer_add_wrapper(int argc, char **argv);
 void cmd_br_sync_wrapper(int argc, char **argv);
 void cmd_br_sync_all_wrapper(int argc, char **argv);

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -2,7 +2,9 @@
 #define PLUGIN_H
 
 int plugin_install(const char *url);
-int plugin_load(const char *name);
+int plugin_load(const char *file);
+int plugin_unload(const char *name);
+int plugin_exec(const char *name);
 void plugin_list(void);
 
 #endif

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -323,6 +323,12 @@ void cmd_plugin_load_wrapper(int argc, char **argv) {
     plugin_load(argv[1]);
 }
 
+void cmd_plugin_unload_wrapper(int argc, char **argv) {
+    ensure_init();
+    if (argc < 2) { printf("usage: PLUGIN_UNLOAD <name>\n"); return; }
+    plugin_unload(argv[1]);
+}
+
 void cmd_br_peer_add_wrapper(int argc, char **argv) {
     ensure_init();
     if (argc < 2) { printf("usage: BR_PEER_ADD <addr>\n"); return; }

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "branch.h"
 #include "ai.h"
+#include "plugin.h"
 
 static void log_agent_error(const char *msg) {
     FILE *f = fopen("AGENT.md", "a");
@@ -87,6 +88,25 @@ int main(void) {
                 char out[64];
                 ai_infer(question, out, sizeof(out));
                 printf("%s\n", out);
+            }
+        } else if (strcmp(cmd, "plugin") == 0) {
+            char *sub = strtok(NULL, " ");
+            if (!sub) {
+                printf("usage: plugin <load|unload|list> <file|name>\n");
+                log_agent_error("plugin missing subcommand");
+            } else if (strcmp(sub, "load") == 0) {
+                char *file = strtok(NULL, " ");
+                if (!file) { printf("missing file\n"); }
+                else if (plugin_load(file) != 0) printf("load failed\n");
+            } else if (strcmp(sub, "unload") == 0) {
+                char *name = strtok(NULL, " ");
+                if (!name) { printf("missing name\n"); }
+                else if (plugin_unload(name) != 0) printf("unload failed\n");
+            } else if (strcmp(sub, "list") == 0) {
+                plugin_list();
+            } else {
+                printf("unknown subcommand %s\n", sub);
+                log_agent_error("plugin unknown subcommand");
             }
         } else {
             printf("Unknown command\n");

--- a/src/plugin_loader.c
+++ b/src/plugin_loader.c
@@ -1,8 +1,8 @@
 #include "plugin.h"
-/* [2025-06-09 06:06 UTC] Simple plugin loader via dlopen
+/* [2025-06-09 06:07 UTC] Hot-swap plugin loader via dlopen
  * by: codex
- * Edge cases: no path validation or unloading mechanism.
- * Next agent must: implement security checks and plugin unload.
+ * Edge cases: minimal error handling and no security checks.
+ * Next agent must: audit plugin paths and sandbox execution.
  */
 #include <stdio.h>
 #include <string.h>
@@ -10,7 +10,12 @@
 
 #define MAX_PLUGINS 4
 
-typedef struct { char name[32]; void *handle; } Plugin;
+typedef struct {
+    char name[32];
+    void *handle;
+    void (*exec)(void);
+    void (*cleanup)(void);
+} Plugin;
 static Plugin plugins[MAX_PLUGINS];
 static int plugin_count;
 
@@ -19,19 +24,78 @@ int plugin_install(const char *url) {
     return 0;
 }
 
-int plugin_load(const char *name) {
+static void normalize_name(const char *path, char *out, size_t outsz) {
+    const char *base = strrchr(path, '/');
+    base = base ? base + 1 : path;
+    strncpy(out, base, outsz - 1);
+    out[outsz - 1] = '\0';
+    char *dot = strstr(out, ".so");
+    if (dot) *dot = '\0';
+}
+
+int plugin_load(const char *file) {
     if (plugin_count >= MAX_PLUGINS) return -1;
-    char path[64];
-    snprintf(path, sizeof(path), "build/plugins/%s.so", name);
+    char path[128];
+    if (strchr(file, '/'))
+        snprintf(path, sizeof(path), "%s", file);
+    else
+        snprintf(path, sizeof(path), "build/plugins/%s.so", file);
+
     void *h = dlopen(path, RTLD_NOW);
     if (!h) { printf("dlopen failed: %s\n", dlerror()); return -1; }
-    void (*entry)(void) = dlsym(h, "plugin_entry");
-    if (!entry) { printf("no entry\n"); dlclose(h); return -1; }
-    strncpy(plugins[plugin_count].name, name, sizeof(plugins[plugin_count].name)-1);
+
+    int (*init)(void) = dlsym(h, "plugin_init");
+    void (*exec)(void) = dlsym(h, "plugin_exec");
+    void (*cleanup)(void) = dlsym(h, "plugin_cleanup");
+    if (!init || !exec || !cleanup) {
+        printf("plugin interface missing\n");
+        dlclose(h);
+        return -1;
+    }
+
+    if (init() != 0) {
+        printf("init failed\n");
+        dlclose(h);
+        return -1;
+    }
+
+    char norm[32];
+    normalize_name(path, norm, sizeof(norm));
+    strncpy(plugins[plugin_count].name, norm, sizeof(plugins[plugin_count].name)-1);
     plugins[plugin_count].handle = h;
+    plugins[plugin_count].exec = exec;
+    plugins[plugin_count].cleanup = cleanup;
     plugin_count++;
-    entry();
+
+    exec();
+    printf("Loaded %s\n", norm);
     return 0;
+}
+
+int plugin_exec(const char *name) {
+    for (int i=0;i<plugin_count;i++)
+        if (strcmp(plugins[i].name, name)==0) {
+            plugins[i].exec();
+            return 0;
+        }
+    return -1;
+}
+
+int plugin_unload(const char *name) {
+    for (int i=0;i<plugin_count;i++) {
+        if (strcmp(plugins[i].name, name)==0) {
+            if (plugins[i].cleanup)
+                plugins[i].cleanup();
+            dlclose(plugins[i].handle);
+            for (int j=i;j<plugin_count-1;j++)
+                plugins[j]=plugins[j+1];
+            plugin_count--;
+            printf("Unloaded %s\n", name);
+            return 0;
+        }
+    }
+    printf("Plugin %s not found\n", name);
+    return -1;
 }
 
 void plugin_list(void) {


### PR DESCRIPTION
## Summary
- implement plugin interface with init/exec/cleanup
- add plugin_unload and exec helpers
- expose `plugin` command in the REPL
- update sample plugin and demo for unload lifecycle
- document plugin usage
- record changes in AGENT and PATCHLOG

## Testing
- `make host`
- `make plugins`
- `./examples/plugin_demo.sh`


------
https://chatgpt.com/codex/tasks/task_e_68467b8826fc8325b3a2bdfed9d9f98e