### PR TITLE
feat(policy): add policy engine and sandboxing [agent-mem]

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -96,3 +96,14 @@ by: codex
 - Design persistent storage backend or VFS integration in fs.c
 - Confirm usage/reconcile with new system in branch.c
 - Replace AI stub with real backend and add retries in ai.c
+
+## [2025-06-09 06:40 UTC] — policy engine & sandbox [agent-mem]
+by: codex
+- Implemented JSON-based policy rules with branch/app context.
+- Added `policy_check_ctx` API and integrated checks in FS commands.
+- Introduced `bm_current_name` helper for branch-aware enforcement.
+- Updated policy demo to exercise deny/allow via JSON.
+- Limitations: parser fragile, no persistent storage, enforcement covers only FS.
+Next agent must:
+- Extend sandbox hooks to memory, AI, and plugins.
+- Persist policy configs and validate JSON input.

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -74,3 +74,13 @@ by: codex
 - `./examples/plugin_demo.sh`
 - `./examples/ai_service_demo.sh`
 - `echo 'ai hello\nexit' | ./build/host_test` *(fails: openai module missing)*
+
+## [2025-06-09 06:40 UTC] — policy engine & sandbox [agent-mem]
+### Changes
+- Reworked policy engine to load JSON rules with per-branch and app context.
+- Added `policy_check_ctx` API and default `policy_check` wrapper.
+- Introduced `bm_current_name` helper and enforcement hooks in FS wrappers.
+- Updated policy demo to use JSON rules.
+### Tests
+- `make policy`
+- `./examples/policy_demo.sh`

--- a/examples/policy_demo.c
+++ b/examples/policy_demo.c
@@ -1,10 +1,12 @@
 #include "policy.h"
 #include <stdio.h>
+
 int main(void){
-    policy_load("allow-all");
-    if(policy_check("test")) printf("allowed\n");
-    /* load deny rule and verify blocking */
-    policy_load("deny test");
-    if(!policy_check("test")) printf("denied\n");
+    const char *allow_json = "[{\"syscall\":\"TEST\",\"allow\":true}]";
+    const char *deny_json  = "[{\"syscall\":\"TEST\",\"allow\":false}]";
+    policy_load(allow_json);
+    if(policy_check("TEST")) printf("allowed\n");
+    policy_load(deny_json);
+    if(!policy_check("TEST")) printf("denied\n");
     return 0;
 }

--- a/include/branch.h
+++ b/include/branch.h
@@ -50,6 +50,9 @@ void bm_vm_list(void);
 int bm_vm_switch(int id);
 int bm_vm_stop(int id);
 
+/* Return name of current branch or "default" if none */
+const char *bm_current_name(void);
+
 // Networking
 int br_peer_add(const char *addr);
 int br_sync(void);

--- a/include/policy.h
+++ b/include/policy.h
@@ -1,7 +1,11 @@
 #ifndef POLICY_H
 #define POLICY_H
 
-void policy_load(const char *script);
+/* Load policy rules from JSON string */
+void policy_load(const char *json);
+/* Check action against current policy for a branch/app */
+int policy_check_ctx(const char *branch, const char *app, const char *action);
+/* Backwards compatibility helper using default context */
 int policy_check(const char *action);
 
 #endif

--- a/src/branch_manager.c
+++ b/src/branch_manager.c
@@ -211,3 +211,9 @@ int bm_graph(BranchGraph *out) {
     return graph.count;
 }
 
+const char *bm_current_name(void) {
+    if (current_branch >= 0 && current_branch < graph.count)
+        return graph.branches[current_branch].name;
+    return "default";
+}
+

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -100,6 +100,11 @@ void cmd_mem_free_wrapper(int argc, char **argv) {
 
 void cmd_fs_open_wrapper(int argc, char **argv) {
     ensure_init();
+    if (!policy_check_ctx(bm_current_name(), "repl", "FS_OPEN")) {
+        printf("Denied by policy\n");
+        log_checklist("FS_OPEN denied");
+        return;
+    }
     if (argc < 3) {
         printf("Error: usage: FS_OPEN <name> <mode>\n");
         log_checklist("FS_OPEN missing arg");
@@ -116,6 +121,11 @@ void cmd_fs_open_wrapper(int argc, char **argv) {
 
 void cmd_fs_write_wrapper(int argc, char **argv) {
     ensure_init();
+    if (!policy_check_ctx(bm_current_name(), "repl", "FS_WRITE")) {
+        printf("Denied by policy\n");
+        log_checklist("FS_WRITE denied");
+        return;
+    }
     if (argc < 3) {
         printf("Error: usage: FS_WRITE <fd> <text>\n");
         log_checklist("FS_WRITE missing arg");
@@ -140,6 +150,11 @@ void cmd_fs_write_wrapper(int argc, char **argv) {
 
 void cmd_fs_read_wrapper(int argc, char **argv) {
     ensure_init();
+    if (!policy_check_ctx(bm_current_name(), "repl", "FS_READ")) {
+        printf("Denied by policy\n");
+        log_checklist("FS_READ denied");
+        return;
+    }
     if (argc < 3) {
         printf("Error: usage: FS_READ <fd> <bytes>\n");
         log_checklist("FS_READ missing arg");
@@ -174,6 +189,11 @@ void cmd_fs_read_wrapper(int argc, char **argv) {
 
 void cmd_fs_close_wrapper(int argc, char **argv) {
     ensure_init();
+    if (!policy_check_ctx(bm_current_name(), "repl", "FS_CLOSE")) {
+        printf("Denied by policy\n");
+        log_checklist("FS_CLOSE denied");
+        return;
+    }
     if (argc < 2) {
         printf("Error: usage: FS_CLOSE <fd>\n");
         log_checklist("FS_CLOSE missing arg");

--- a/src/policy.c
+++ b/src/policy.c
@@ -2,21 +2,82 @@
 #include <stdio.h>
 #include <string.h>
 
-static char deny_action[32];
+/* [2025-06-09 06:06 UTC] Simple policy engine
+ * by: codex
+ * Edge cases: naive JSON parser, no persistence or integrity checks.
+ */
 
-void policy_load(const char *script) {
-    deny_action[0] = '\0';
-    if (script && strncmp(script, "deny ", 5) == 0) {
-        strncpy(deny_action, script + 5, sizeof(deny_action) - 1);
+#define MAX_RULES 32
+
+typedef struct {
+    char branch[32];
+    char app[32];
+    char action[32];
+    int allow; /* 1 allow, 0 deny */
+} PolicyRule;
+
+static PolicyRule rules[MAX_RULES];
+static int rule_count;
+
+static void reset_rules(void) {
+    rule_count = 0;
+    memset(rules, 0, sizeof(rules));
+}
+
+void policy_load(const char *json) {
+    reset_rules();
+    if (!json) return;
+    const char *p = json;
+    while ((p = strchr(p, '{')) && rule_count < MAX_RULES) {
+        PolicyRule *r = &rules[rule_count];
+        strcpy(r->branch, "*");
+        strcpy(r->app, "*");
+        r->action[0] = '\0';
+        r->allow = 1;
+        const char *f;
+        if ((f = strstr(p, "\"branch\"")))
+            sscanf(strchr(f, ':') + 1, "\"%31[^\"]\"", r->branch);
+        if ((f = strstr(p, "\"app\"")))
+            sscanf(strchr(f, ':') + 1, "\"%31[^\"]\"", r->app);
+        if ((f = strstr(p, "\"syscall\"")))
+            sscanf(strchr(f, ':') + 1, "\"%31[^\"]\"", r->action);
+        if ((f = strstr(p, "\"allow\""))) {
+            char val[6];
+            sscanf(strchr(f, ':') + 1, " %5[^,}\n]", val);
+            r->allow = (val[0]=='t' || val[0]=='1');
+        }
+        if ((f = strstr(p, "\"deny\""))) {
+            char val[6];
+            sscanf(strchr(f, ':') + 1, " %5[^,}\n]", val);
+            r->allow = !(val[0]=='t' || val[0]=='1');
+        }
+        if (r->action[0]) rule_count++;
+        p = strchr(p, '}');
+        if (!p) break;
+        p++;
     }
-    printf("policy loaded: %s\n", script ? script : "");
+    printf("policy loaded: %d rules\n", rule_count);
+}
+
+static int match(const char *rule_val, const char *ctx_val) {
+    return strcmp(rule_val, "*")==0 || !ctx_val || strcmp(rule_val, ctx_val)==0;
+}
+
+int policy_check_ctx(const char *branch, const char *app, const char *action) {
+    for (int i=0;i<rule_count;i++) {
+        PolicyRule *r = &rules[i];
+        if (match(r->branch, branch) && match(r->app, app) &&
+            strcmp(r->action, action)==0) {
+            if (!r->allow) {
+                FILE *f = fopen("AOS-CHECKLIST.log", "a");
+                if (f) { fprintf(f, "policy deny %s\n", action); fclose(f); }
+            }
+            return r->allow;
+        }
+    }
+    return 1; /* default allow */
 }
 
 int policy_check(const char *action) {
-    if (deny_action[0] && action && strcmp(action, deny_action) == 0) {
-        FILE *f = fopen("AOS-CHECKLIST.log", "a");
-        if (f) { fprintf(f, "policy deny %s\n", action); fclose(f); }
-        return 0;
-    }
-    return 1;
+    return policy_check_ctx("*", "*", action);
 }


### PR DESCRIPTION
## Summary
- enhance policy engine with JSON rules and branch/app context
- add `bm_current_name` helper to branch manager
- enforce policy in filesystem command wrappers
- update policy demo for JSON rules
- document changes in AGENT and PATCHLOG

## Testing
- `make policy`
- `./examples/policy_demo.sh`
- `make host`
- `make plugins`
- `./examples/plugin_demo.sh`
- `make ai-service`
- `./examples/ai_service_demo.sh`
- `echo 'ai hello\nexit' | ./build/host_test` *(fails: openai module missing)*
- `make branch-net`


------
https://chatgpt.com/codex/tasks/task_e_684691f414948325a0ac1fc00f80ec82