### PR TITLE
feat(net): add TCP/IP stack and demo [agent-mem]

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -81,6 +81,12 @@ by: codex
 - `./examples/ai_service_demo.sh`
 - `echo 'ai hello\nexit' | ./build/host_test` *(fails: openai module missing)*
 
+## [2025-06-09 07:51 UTC] — minimal network stack [agent-mem]
+by: codex
+- Introduced `net` subsystem with TCP wrappers (open, bind, listen, accept, connect, send, recv).
+- Added `net_echo` demo and build target.
+- Host build now links the new subsystem.
+
 ## UNRESOLVED ISSUES
 - Network service lacks graceful shutdown and authentication.
 - Plugin loader needs path validation and sandboxing.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all generate host bare run clean ui ui-check branch-vm plugins iso efi branch-net ai-service policy
+.PHONY: all generate host bare run clean ui ui-check branch-vm plugins iso efi branch-net ai-service policy net
 
 all: host bare
 
@@ -14,7 +14,7 @@ NCURSES_LIBS := $(shell pkg-config --libs ncurses 2>/dev/null || echo -lncurses)
 host: generate subsystems
 	@echo "→ Building host binaries"
 	@mkdir -p build
-	gcc -Iinclude -Isubsystems/memory -Isubsystems/fs -Isubsystems/ai -Isubsystems/branch $(NCURSES_CFLAGS) src/main.c src/interpreter.c src/branch_manager.c src/ui_graph.c src/branch_vm.c src/plugin_loader.c src/branch_net.c src/ai_syscall.c src/policy.c src/memory.c command_map.c commands.c subsystems/memory/memory.c subsystems/fs/fs.c subsystems/ai/ai.c subsystems/branch/branch.c $(NCURSES_LIBS) -ldl -lcurl -lm -o build/host_test
+	gcc -Iinclude -Isubsystems/memory -Isubsystems/fs -Isubsystems/ai -Isubsystems/branch -Isubsystems/net $(NCURSES_CFLAGS) src/main.c src/interpreter.c src/branch_manager.c src/ui_graph.c src/branch_vm.c src/plugin_loader.c src/branch_net.c src/ai_syscall.c src/policy.c src/memory.c command_map.c commands.c subsystems/memory/memory.c subsystems/fs/fs.c subsystems/ai/ai.c subsystems/branch/branch.c subsystems/net/net.c $(NCURSES_LIBS) -ldl -lcurl -lm -o build/host_test
 	gcc -Iinclude $(NCURSES_CFLAGS) src/ui_graph.c src/branch_manager.c src/ui_main.c $(NCURSES_LIBS) -lm -o build/ui_graph
 
 # 3. Build bare-metal image
@@ -98,6 +98,11 @@ policy:
 	@mkdir -p build
 	gcc -Iinclude src/policy.c examples/policy_demo.c -o build/policy_demo
 
+net:
+	       @echo "→ Building net echo demo"
+	       @mkdir -p build
+	       gcc -Isubsystems/net subsystems/net/net.c examples/net_echo.c -o build/net_echo
+
 test: host branch
 	@echo "→ Running branch demo"
 	@./build/branch_demo >/tmp/branch_demo.out && cat /tmp/branch_demo.out
@@ -111,7 +116,7 @@ iso: efi
 	@echo "→ Creating aos.iso"
 	touch aos.iso
 
-subsystems: memory fs ai branch
+subsystems: memory fs ai branch net
 
 ui: host
 	@echo "UI built via host target"

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -74,3 +74,12 @@ by: codex
 - `./examples/plugin_demo.sh`
 - `./examples/ai_service_demo.sh`
 - `echo 'ai hello\nexit' | ./build/host_test` *(fails: openai module missing)*
+
+## [2025-06-09 07:51 UTC] — TCP stack demo [agent-mem]
+### Changes
+- Added `subsystems/net` with basic TCP wrappers.
+- New example `net_echo` and `make net` target.
+### Tests
+- `make net`
+- `./build/net_echo --server --port 12345 &`
+- `./build/net_echo --host 127.0.0.1 --port 12345`

--- a/examples/net_echo.c
+++ b/examples/net_echo.c
@@ -1,0 +1,54 @@
+#include "net.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    int server = 0;
+    const char *host = "127.0.0.1";
+    int port = 12345;
+
+    static struct option opts[] = {
+        {"server", no_argument, 0, 's'},
+        {"host", required_argument, 0, 'h'},
+        {"port", required_argument, 0, 'p'},
+        {0,0,0,0}
+    };
+    int opt;
+    while ((opt = getopt_long(argc, argv, "sh:p:", opts, NULL)) != -1) {
+        switch (opt) {
+            case 's': server = 1; break;
+            case 'h': host = optarg; break;
+            case 'p': port = atoi(optarg); break;
+        }
+    }
+
+    if (server) {
+        int s = net_socket();
+        net_bind(s, host, port);
+        net_listen(s, 1);
+        int c = net_accept(s);
+        char buf[256];
+        int n = net_recv(c, buf, sizeof(buf));
+        if (n > 0) net_send(c, buf, n);
+        net_close(c);
+        net_close(s);
+    } else {
+        int s = net_socket();
+        if (net_connect(s, host, port) < 0) {
+            perror("connect");
+            return 1;
+        }
+        net_send(s, "ping", 4);
+        char buf[256];
+        int n = net_recv(s, buf, sizeof(buf)-1);
+        if (n > 0) {
+            buf[n] = '\0';
+            printf("%s\n", buf);
+        }
+        net_close(s);
+    }
+    return 0;
+}

--- a/subsystems/net/net.c
+++ b/subsystems/net/net.c
@@ -1,0 +1,46 @@
+#include "net.h"
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+
+int net_socket(void) {
+    return socket(AF_INET, SOCK_STREAM, 0);
+}
+
+int net_bind(int sock, const char *ip, int port) {
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = ip ? inet_addr(ip) : INADDR_ANY;
+    return bind(sock, (struct sockaddr*)&addr, sizeof(addr));
+}
+
+int net_listen(int sock, int backlog) {
+    return listen(sock, backlog);
+}
+
+int net_accept(int sock) {
+    return accept(sock, NULL, NULL);
+}
+
+int net_connect(int sock, const char *ip, int port) {
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr(ip ? ip : "127.0.0.1");
+    return connect(sock, (struct sockaddr*)&addr, sizeof(addr));
+}
+
+int net_send(int sock, const void *buf, int len) {
+    return send(sock, buf, len, 0);
+}
+
+int net_recv(int sock, void *buf, int len) {
+    return recv(sock, buf, len, 0);
+}
+
+void net_close(int sock) {
+    close(sock);
+}

--- a/subsystems/net/net.h
+++ b/subsystems/net/net.h
@@ -1,0 +1,13 @@
+#ifndef NET_H
+#define NET_H
+
+int net_socket(void);
+int net_bind(int sock, const char *ip, int port);
+int net_listen(int sock, int backlog);
+int net_accept(int sock);
+int net_connect(int sock, const char *ip, int port);
+int net_send(int sock, const void *buf, int len);
+int net_recv(int sock, void *buf, int len);
+void net_close(int sock);
+
+#endif


### PR DESCRIPTION
## Summary
- implement minimal TCP wrappers in new `net` subsystem
- add echo server/client example using the wrappers
- build `net_echo` via `make net` and include in host build
- document networking stack addition in `AGENT.md` and `PATCHLOG.md`

## Testing
- `make host`
- `make net`
- `./build/net_echo --server --port 16001 &`
- `./build/net_echo --host 127.0.0.1 --port 16001`

------
https://chatgpt.com/codex/tasks/task_e_684691e5c5f88325a974ed668e597545