### PR TITLE
feat(net): tcp/ip stack and basic services [agent-mem]

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -131,3 +131,8 @@ Next agent must:
 - Persist policy configs and validate JSON input.
 - Integrate web UI with live branch data via IPC and secure the HTTP service with tests.
 AI error: missing OPENAI_API_KEY
+## [2025-06-09 08:10 UTC] — extended TCP/IP stack [agent-mem]
+by: codex
+- Added UDP helpers in `subsystems/net` for sendto/recvfrom.
+- Implemented simple `http_server` example and build target.
+- Updated README with networking usage and added demo scripts.

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,14 @@ policy:
 	gcc -Iinclude src/policy.c examples/policy_demo.c -o build/policy_demo
 
 net:
-	       @echo "→ Building net echo demo"
-	       @mkdir -p build
-	       gcc -Isubsystems/net subsystems/net/net.c examples/net_echo.c -o build/net_echo
+	@echo "→ Building net echo demo"
+	@mkdir -p build
+	gcc -Isubsystems/net subsystems/net/net.c examples/net_echo.c -o build/net_echo
+
+net-http:
+	@echo "→ Building http server demo"
+	@mkdir -p build
+	gcc -Isubsystems/net subsystems/net/net.c examples/http_server.c -o build/http_server
 
 test: host branch
 	@echo "→ Running branch demo"

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -133,3 +133,13 @@ by: codex
 - `./examples/plugin_demo.sh`
 - `./examples/ai_service_demo.sh`
 - `echo "ai test\nexit" | ./build/host_test` *(fails: openai module missing)*
+## [2025-06-09 08:10 UTC] — extended TCP/IP stack [agent-mem]
+### Changes
+- Added UDP helpers and updated net subsystem.
+- New `http_server` example with `net-http` build target.
+- Added demo scripts and README networking section.
+### Tests
+- `make net`
+- `./examples/net_echo_demo.sh`
+- `make net-http`
+- `./examples/net_http_demo.sh`

--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ make policy
 
 Loads a policy script and performs a check.
 
+## Networking
+
+```bash
+make net
+./build/net_echo --server --port 12345 &
+./build/net_echo --host 127.0.0.1 --port 12345
+make net-http
+./examples/net_http_demo.sh
+```
+
+Demonstrates TCP echo and a simple HTTP server.
+
 ## Checklist Log
 
 The build process writes warnings and errors to `AOS-CHECKLIST.log`.

--- a/examples/http_server.c
+++ b/examples/http_server.c
@@ -1,0 +1,37 @@
+#include "net.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <sys/socket.h>
+
+int main(int argc, char **argv) {
+    int port = 8080;
+    static struct option opts[] = {
+        {"port", required_argument, 0, 'p'},
+        {0,0,0,0}
+    };
+    int opt;
+    while ((opt = getopt_long(argc, argv, "p:", opts, NULL)) != -1) {
+        if (opt == 'p') port = atoi(optarg);
+    }
+
+    int s = net_socket();
+    if (s < 0) { perror("socket"); return 1; }
+    int yes = 1;
+    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+    if (net_bind(s, NULL, port) < 0) { perror("bind"); return 1; }
+    net_listen(s, 1);
+    printf("HTTP server on port %d\n", port);
+    int c = net_accept(s);
+    if (c < 0) { perror("accept"); return 1; }
+    char buf[1024];
+    int n = net_recv(c, buf, sizeof(buf)-1);
+    if (n > 0) {
+        const char *resp = "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\nHello from AOS\n";
+        net_send(c, resp, strlen(resp));
+    }
+    net_close(c);
+    net_close(s);
+    return 0;
+}

--- a/examples/net_echo_demo.sh
+++ b/examples/net_echo_demo.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Demo for TCP echo
+./build/net_echo --server --port 12345 &
+PID=$!
+sleep 1
+./build/net_echo --host 127.0.0.1 --port 12345
+kill $PID

--- a/examples/net_http_demo.sh
+++ b/examples/net_http_demo.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Demo for basic HTTP server
+PORT=9001
+./build/http_server --port $PORT &
+PID=$!
+sleep 1
+curl -s http://127.0.0.1:$PORT/
+kill $PID 2>/dev/null

--- a/subsystems/net/net.c
+++ b/subsystems/net/net.c
@@ -44,3 +44,23 @@ int net_recv(int sock, void *buf, int len) {
 void net_close(int sock) {
     close(sock);
 }
+
+int net_udp_socket(void) {
+    return socket(AF_INET, SOCK_DGRAM, 0);
+}
+
+int net_sendto(int sock, const char *ip, int port, const void *buf, int len) {
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = ip ? inet_addr(ip) : INADDR_BROADCAST;
+    return sendto(sock, buf, len, 0, (struct sockaddr*)&addr, sizeof(addr));
+}
+
+int net_recvfrom(int sock, char *out_ip, int *out_port, void *buf, int len) {
+    struct sockaddr_in addr; socklen_t slen = sizeof(addr);
+    int n = recvfrom(sock, buf, len, 0, (struct sockaddr*)&addr, &slen);
+    if (n >= 0 && out_ip) strcpy(out_ip, inet_ntoa(addr.sin_addr));
+    if (n >= 0 && out_port) *out_port = ntohs(addr.sin_port);
+    return n;
+}

--- a/subsystems/net/net.h
+++ b/subsystems/net/net.h
@@ -10,4 +10,9 @@ int net_send(int sock, const void *buf, int len);
 int net_recv(int sock, void *buf, int len);
 void net_close(int sock);
 
+/* UDP helpers */
+int net_udp_socket(void);
+int net_sendto(int sock, const char *ip, int port, const void *buf, int len);
+int net_recvfrom(int sock, char *out_ip, int *out_port, void *buf, int len);
+
 #endif


### PR DESCRIPTION
## Summary
- extend networking subsystem with UDP helpers
- add a simple HTTP server example and demo scripts
- integrate new targets in the Makefile and document usage
- update agent memory and patch logs

## Testing
- `make net`
- `make net-http`
- `./examples/net_echo_demo.sh`
- `./examples/net_http_demo.sh`
- `ping -c 1 127.0.0.1`


------
https://chatgpt.com/codex/tasks/task_e_68469b08be0083259357a0e1a0c33f3d