### PR TITLE
feat(plugin): sandboxed plugin loader [agent-mem]

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -85,6 +85,12 @@ by: codex
 - Added env var check and latency logging in `ai_syscall.c`.
 - Updated README with new instructions.
 AI error: missing OPENAI_API_KEY
+
+## [2025-06-09 08:30 UTC] — sandboxed plugin loader [agent-mem]
+by: codex
+- Added rlimit-based sandbox for plugin init/exec/cleanup.
+- Introduced path validation and hook registration API.
+- Default hook ensures plugins load only from `build/plugins/`.
 AI error: missing OPENAI_API_KEY
 AI latency 204 ms
 AI backend error rc=30720 output=Traceback (most recent call last):
@@ -131,3 +137,4 @@ Next agent must:
 - Persist policy configs and validate JSON input.
 - Integrate web UI with live branch data via IPC and secure the HTTP service with tests.
 AI error: missing OPENAI_API_KEY
+plugin validation failed build/plugins/missing.so

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -133,3 +133,11 @@ by: codex
 - `./examples/plugin_demo.sh`
 - `./examples/ai_service_demo.sh`
 - `echo "ai test\nexit" | ./build/host_test` *(fails: openai module missing)*
+
+## [2025-06-09 08:30 UTC] — sandboxed plugin loader [agent-mem]
+### Changes
+- Added validation hook API and builtin path check.
+- Plugin init/exec/cleanup run under CPU/memory limits.
+### Tests
+- `make plugins`
+- `./examples/plugin_demo.sh`

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -1,10 +1,12 @@
 #ifndef PLUGIN_H
 #define PLUGIN_H
+/* plugin system interface with sandbox hooks */
 
 int plugin_install(const char *url);
 int plugin_load(const char *file);
 int plugin_unload(const char *name);
 int plugin_exec(const char *name);
 void plugin_list(void);
+int plugin_register_hook(int (*hook)(const char *));
 
 #endif


### PR DESCRIPTION
## Summary
- sandbox plugin loader with validation hooks
- limit plugin CPU and memory usage via rlimits
- log plugin load failures

## Testing
- `make plugins`
- `./examples/plugin_demo.sh`


------
https://chatgpt.com/codex/tasks/task_e_68469b0ff20c8325a54a75c3c4e8c9ee