### PR TITLE
Meta sweep: unify docs and logs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -76,7 +76,6 @@ Initial repository had no AGENT log. `PATCHLOG.md` captured early development on
 - Integrate persistent storage backend with the filesystem.
 - Integrate web UI with live branch data and secure HTTP service.
 - Expand smoke tests with CI coverage and rollback support.
-plugin validation failed build/plugins/missing.so
 
 ## [2025-06-09 09:30 UTC] documentation sweep [agent-mem]
 - Expanded README with architecture overview and troubleshooting notes.
@@ -137,3 +136,26 @@ Next agent must:
 
 Next agent must:
 - Extend profiler to collect multiple samples and integrate with logging.
+
+## Baton Pass
+- Continue expanding subsystem READMEs with usage notes.
+- Review remaining subsystems for missing comments.
+- Expand tests across subsystems.
+- Flesh out dev and security subsystem APIs.
+- Use AosError consistently.
+- Update ROADMAP.md as milestones land.
+- Monitor community channels for CODE_OF_CONDUCT compliance.
+- Extend profiler to gather multiple samples and hook into logging.
+
+## [2025-06-09 09:58 UTC] meta sweep [agent-mem]
+- Cleaned open issues and unified baton pass list.
+- Added docs/README and profiler docblocks.
+- Updated README with meta-log links.
+
+
+## [2025-06-09 10:12 UTC] meta polish [agent-mem]
+- Added README placeholders for remaining subsystems.
+- Fixed ui_graph build by linking logging sources.
+- Linked profiler stub from README.
+- Corrected bare_metal_os Makefile tabs so `make clean` works.
+- Consolidated baton pass list.

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ NCURSES_LIBS := $(shell pkg-config --libs ncurses 2>/dev/null || echo -lncurses)
 host: generate subsystems
 	@echo "→ Building host binaries"
 	@mkdir -p build
-        gcc -rdynamic -Iinclude -Isubsystems/memory -Isubsystems/fs -Isubsystems/ai -Isubsystems/branch -Isubsystems/net $(NCURSES_CFLAGS) src/main.c src/interpreter.c src/branch_manager.c src/ui_graph.c src/branch_vm.c src/plugin_loader.c src/branch_net.c src/ai_syscall.c src/policy.c src/memory.c src/app_runtime.c src/config.c src/logging.c src/error.c command_map.c commands.c subsystems/memory/memory.c subsystems/fs/fs.c subsystems/ai/ai.c subsystems/branch/branch.c subsystems/net/net.c $(NCURSES_LIBS) -ldl -lcurl -lm -o build/host_test
-	gcc -Iinclude $(NCURSES_CFLAGS) src/ui_graph.c src/branch_manager.c src/ui_main.c $(NCURSES_LIBS) -lm -o build/ui_graph
+	gcc -rdynamic -Iinclude -Isubsystems/memory -Isubsystems/fs -Isubsystems/ai -Isubsystems/branch -Isubsystems/net $(NCURSES_CFLAGS) src/main.c src/interpreter.c src/branch_manager.c src/ui_graph.c src/branch_vm.c src/plugin_loader.c src/branch_net.c src/ai_syscall.c src/policy.c src/memory.c src/app_runtime.c src/config.c src/logging.c src/error.c command_map.c commands.c subsystems/memory/memory.c subsystems/fs/fs.c subsystems/ai/ai.c subsystems/branch/branch.c subsystems/net/net.c $(NCURSES_LIBS) -ldl -lcurl -lm -o build/host_test
+	gcc -Iinclude $(NCURSES_CFLAGS) src/ui_graph.c src/branch_manager.c \
+	    src/logging.c src/error.c src/ui_main.c $(NCURSES_LIBS) -lm -o build/ui_graph
 
 # 3. Build bare-metal image
 bare: generate
@@ -60,7 +61,7 @@ clean:
 memory:
 	@echo "→ Building memory demo"
 	@mkdir -p build
-	gcc -Isubsystems/memory subsystems/memory/memory.c src/memory.c examples/memory_demo.c -o build/memory_demo
+	gcc -Isubsystems/memory -Iinclude subsystems/memory/memory.c src/memory.c examples/memory_demo.c src/logging.c src/error.c -o build/memory_demo
 
 fs:
 	@echo "→ Building fs demo"
@@ -143,22 +144,22 @@ test-policy: policy
 	./examples/policy_smoke.sh
 
 test-net: net
-        ./examples/net_echo_test.sh
+	./examples/net_echo_test.sh
 
 test-unit:
-@echo "→ Running unit tests"
-@mkdir -p build/tests
-gcc -Isubsystems/memory -Iinclude tests/unit/test_memory.c \
-subsystems/memory/memory.c -o build/tests/test_memory
-@./build/tests/test_memory
+	@echo "→ Running unit tests"
+	@mkdir -p build/tests
+	gcc -Isubsystems/memory -Iinclude tests/unit/test_memory.c \
+	subsystems/memory/memory.c src/logging.c src/error.c -o build/tests/test_memory
+	@./build/tests/test_memory
 
 test-integration:
-@echo "→ Running integration tests"
-@mkdir -p build/tests
-gcc -Isubsystems/fs -Isubsystems/memory -Iinclude \
-tests/integration/test_fs_memory.c \
-subsystems/fs/fs.c subsystems/memory/memory.c -o build/tests/test_fs
-@./build/tests/test_fs
+	@echo "→ Running integration tests"
+	@mkdir -p build/tests
+	gcc -Isubsystems/fs -Isubsystems/memory -Iinclude \
+	tests/integration/test_fs_memory.c \
+	subsystems/fs/fs.c subsystems/memory/memory.c src/logging.c src/error.c -o build/tests/test_fs
+	@./build/tests/test_fs
 
 efi:
 	@echo "→ Building EFI stub"

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -284,3 +284,23 @@ by: codex
 - Documented basic usage in docs/profiler_usage.md.
 ### Tests
 - `grep profiler_start -n src/profiler.c`
+
+## [2025-06-09 09:58 UTC] — meta sweep [agent-mem]
+### Changes
+- Added docs/README.md and updated README links.
+- Inserted profiler documentation comments.
+- Consolidated AGENT.md open tasks.
+### Tests
+- `make test-unit`
+- `make test-integration`
+
+## [2025-06-09 10:12 UTC] — meta polish [agent-mem]
+### Changes
+- Added subsystem README placeholders and referenced profiler usage in README.
+- Fixed Makefile ui_graph target to link logging sources.
+- Corrected bare_metal_os Makefile tabs for clean target.
+- Updated baton pass list in AGENT.md.
+### Tests
+- `make host`
+- `make test-unit`
+- `make test-integration`

--- a/README.md
+++ b/README.md
@@ -223,3 +223,5 @@ cat AOS-CHECKLIST.log
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
 Additional developer documentation is available under the [docs/](docs/) directory.
+See [docs/profiler_usage.md](docs/profiler_usage.md) for the profiler stub.
+See [AGENT.md](AGENT.md) and [PATCHLOG.md](PATCHLOG.md) for development logs. The roadmap is maintained in [ROADMAP.md](ROADMAP.md).

--- a/bare_metal_os/Makefile
+++ b/bare_metal_os/Makefile
@@ -17,10 +17,10 @@ kernel.bin: kernel.c memory.c fs.c branch.c interpreter/command_interpreter.c ..
 	$(CC) $(CFLAGS) -I.. -I../include -c interpreter/command_interpreter.c -o command_interpreter.o
 	$(CC) $(CFLAGS) -I.. -I../include -c ../commands.c -o commands.o
 	$(CC) $(CFLAGS) -I.. -I../include -c ../command_map.c -o command_map.o
-        $(CC) $(CFLAGS) -I.. -I../include -c config_stub.c -o config.o
-        $(CC) $(CFLAGS) -I.. -I../include -c ../logging.c -o logging.o
-        $(CC) $(CFLAGS) -I.. -I../include -c ../error.c -o error.o
-        $(LD) $(LDFLAGS) kernel.o memory.o fs.o branch.o command_interpreter.o commands.o command_map.o config.o logging.o error.o -o kernel.elf
+	$(CC) $(CFLAGS) -I.. -I../include -c config_stub.c -o config.o
+	$(CC) $(CFLAGS) -I.. -I../include -c ../logging.c -o logging.o
+	$(CC) $(CFLAGS) -I.. -I../include -c ../error.c -o error.o
+	$(LD) $(LDFLAGS) kernel.o memory.o fs.o branch.o command_interpreter.o commands.o command_map.o config.o logging.o error.o -o kernel.elf
 	objcopy -O binary kernel.elf kernel.bin
 
 bootloader.bin: bootloader.asm kernel.bin

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This directory contains additional guides for AOS.
+
+- `getting_started.md` – build and run instructions.
+- `system_architecture.md` – subsystem overview.
+- `profiler_usage.md` – profiler stub reference.
+
+Refer to [../AGENT.md](../AGENT.md) and [../PATCHLOG.md](../PATCHLOG.md) for development history.

--- a/include/profiler.h
+++ b/include/profiler.h
@@ -1,3 +1,5 @@
+/* Minimal profiler stub. Future work should collect multiple samples and integrate with logging. */
+
 #ifndef AOS_PROFILER_H
 #define AOS_PROFILER_H
 

--- a/src/error.c
+++ b/src/error.c
@@ -11,4 +11,4 @@ const char *aos_strerror(AosError err) {
     default: return "unknown";
     }
 }
-#include "error.h"\nAosError aos_last_error = AOS_OK;
+AosError aos_last_error = AOS_OK;

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -1,3 +1,5 @@
+/* Profiler implementation stub. Measures elapsed time between start and report. TODO: integrate with logging subsystem. */
+
 #include "profiler.h"
 #include <time.h>
 #include <stdio.h>

--- a/subsystems/ai/README.md
+++ b/subsystems/ai/README.md
@@ -1,0 +1,2 @@
+# Ai Subsystem
+This directory contains the ai subsystem sources.

--- a/subsystems/branch/README.md
+++ b/subsystems/branch/README.md
@@ -1,0 +1,2 @@
+# Branch Subsystem
+This directory contains the branch subsystem sources.

--- a/subsystems/fs/README.md
+++ b/subsystems/fs/README.md
@@ -1,0 +1,2 @@
+# Fs Subsystem
+This directory contains the fs subsystem sources.

--- a/subsystems/memory/README.md
+++ b/subsystems/memory/README.md
@@ -1,0 +1,2 @@
+# Memory Subsystem
+This directory contains the memory subsystem sources.

--- a/subsystems/net/README.md
+++ b/subsystems/net/README.md
@@ -1,0 +1,2 @@
+# Net Subsystem
+This directory contains the net subsystem sources.


### PR DESCRIPTION
## Summary
- add subsystem README placeholders and reference profiler docs
- fix ui_graph link flags and clean target spacing
- log meta polish entry and consolidate baton passes

## Testing
- `make host`
- `make test-unit`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_6846ae67d2448325b7d76ddeaef25397