### PR TITLE
Project documentation sweep [agent-mem]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ command_map.c commands.c category_defs.h
 
 build
 packages
+*.log
+AOS-CHECKLIST.log
+aos.iso

--- a/AGENT.md
+++ b/AGENT.md
@@ -159,3 +159,14 @@ Next agent must:
 - Linked profiler stub from README.
 - Corrected bare_metal_os Makefile tabs so `make clean` works.
 - Consolidated baton pass list.
+
+## [2025-06-09 10:28 UTC] documentation sweep [agent-mem]
+- Added MIT `LICENSE` file.
+- Expanded `CONTRIBUTING.md` with workflow notes.
+- Rewrote `CODE_OF_CONDUCT.md` for clarity.
+- Added `docs/command_flow.md` with ASCII diagram and referenced it from `README` and docs index.
+- Updated README with Quickstart, directory map and command flow link.
+- Removed `AOS-CHECKLIST.log` from repository and updated `.gitignore` to exclude logs and build artifacts.
+
+Next agent must:
+- Continue filling out subsystem READMEs and ensure diagrams stay updated.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,10 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-This project adheres to a simple code of conduct: be respectful and inclusive.
-Harassment or discrimination of any kind is not tolerated. Issues and pull
-requests that violate this standard may be closed.
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) in spirit. We expect everyone participating in the AOS community to be respectful and inclusive.
+
+* Be welcoming to newcomers and existing contributors.
+* Assume positive intent and provide constructive feedback.
+* Harassment, discrimination, or abusive language is not tolerated.
+* Report unacceptable behavior by opening an issue or emailing the maintainers.
+
+Maintainers reserve the right to remove contributions or take other appropriate action to enforce these guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,14 @@ Thank you for your interest in improving AOS. The project uses a simple Makefile
 3. Run smoke tests with `make test-memory`, `make test-fs`, `make test-branch`, `make test-plugin`, `make test-policy`, and `make test-net`.
 4. Please ensure `AOS-CHECKLIST.log` is empty before submitting a patch.
 
-All commits must update `AGENT.md` and `PATCHLOG.md` with a timestamped summary
-and a "Next agent must" baton-pass. Follow the existing format when adding
-entries.
+All commits must update `AGENT.md` and `PATCHLOG.md` with a timestamped summary and a "Next agent must" baton-pass. Follow the existing format when adding entries.
 
 ### Style
 - Use tabs for Makefile recipes and spaces elsewhere.
 - Document complex logic with inline comments.
 - Run `make test-unit` and `make test-integration` before sending a pull request.
+
+### Workflow
+- Fork the repository and create topic branches from `main`.
+- Write clear commit messages describing your changes.
+- Submit a pull request and link any relevant issues.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AOS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -304,3 +304,12 @@ by: codex
 - `make host`
 - `make test-unit`
 - `make test-integration`
+## [2025-06-09 10:28 UTC] — docs sweep [agent-mem]
+### Changes
+- Added LICENSE, expanded CONTRIBUTING and CODE_OF_CONDUCT.
+- Removed committed log file and updated .gitignore.
+- Added docs/command_flow.md and linked it from README and docs index.
+- Updated README with Quickstart and directory overview.
+### Tests
+- `make test-unit`
+- `make test-integration`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Minimal experimental OS used for interpreter tests.
 
+## Quickstart
+
+```bash
+git clone https://example.com/AOS.git
+cd AOS
+make host
+./build/host_test
+```
+
+This compiles the host REPL and launches an interactive session.
+
 ## Architecture Overview
 
 AOS is split into a small kernel and a set of host tools. The kernel boots via
@@ -11,6 +22,17 @@ lightweight command line environment. Each subsystem resides under
 `subsystems/` and exposes a header-only API.
 
 For deeper details see [docs/system_architecture.md](docs/system_architecture.md).
+An overview of command dispatch can be found in
+[docs/command_flow.md](docs/command_flow.md).
+
+## What's inside?
+
+- `bare_metal_os/` – kernel sources and boot files
+- `src/` – shared utilities and host code
+- `subsystems/` – memory, fs, branch and other core modules
+- `include/` – public headers used across the project
+- `apps_src/` – sample applications
+- `docs/` – project documentation
 
 ## Build
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,6 @@ This directory contains additional guides for AOS.
 - `getting_started.md` – build and run instructions.
 - `system_architecture.md` – subsystem overview.
 - `profiler_usage.md` – profiler stub reference.
+- `command_flow.md` – REPL command dispatch diagram.
 
 Refer to [../AGENT.md](../AGENT.md) and [../PATCHLOG.md](../PATCHLOG.md) for development history.

--- a/docs/command_flow.md
+++ b/docs/command_flow.md
@@ -1,0 +1,14 @@
+# Command Dispatch Flow
+
+```
++-------+        +------------+      +---------------+
+|  REPL | -----> | Dispatcher | ---> | Subsystem API |
++-------+        +------------+      +---------------+
+                                        |   |   |
+                                        v   v   v
+                                     [fs] [net] [ai]
+```
+
+User commands entered in the REPL are parsed and dispatched to the appropriate
+subsystem. Each subsystem exposes a small C API used both by the kernel and host
+tools.

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -18,6 +18,11 @@ This document provides an overview of the current design.
 3. Subsystems log operations to `AOS-CHECKLIST.log`.
 4. Persistent components write data under the user's home directory.
 
+```
+Kernel -> Subsystems -> Host REPL
+                   \-> Plugins
+```
+
 Diagrams describing the kernel boot sequence, subsystem interactions and data
 flow are referenced here but omitted from the repository. See the project wiki
 for sketches and further design notes.


### PR DESCRIPTION
## Summary
- add MIT LICENSE file
- expand CODE_OF_CONDUCT and CONTRIBUTING guides
- document command flow diagram and link in README
- add Quickstart and directory map to README
- ignore log artifacts and remove AOS-CHECKLIST.log

## Testing
- `make test-unit`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_6846b6b96cf88325bf1681eebd1070a6