### PR TITLE
Universal repo sweep

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -291,7 +291,7 @@ Next agent must:
 
 
 ## Active Baton Passes
-- Resolve clang-tidy warnings and restore failing builds (`host`, `branch-net`).
+- Provide compile_commands.json for clang-tidy, fix warnings and restore failing builds (`host`, `branch-net`).
 - Expand ext2 filesystem backend and add persistence tests.
 - Flesh out device and security subsystem APIs and documentation.
 - Review network branch sync for race conditions and add tests.
@@ -347,3 +347,19 @@ codex/expand-c-unit-tests-and-unify-error-handling
 Next agent must:
 - Verify fresh venv install covers all runtime scripts.
  main
+## [2025-06-09 22:34 UTC] repo hygiene sweep [codex]
+- Ran `pre-commit` after installing hooks and flake8; all checks pass.
+- Executed `clang-format` across sources.
+- `clang-tidy` fails with many warnings treated as errors (see /tmp/clang_tidy.log).
+- Verified `make test` succeeds running unit and integration suites.
+
+Next agent must:
+- Address `clang-tidy` errors and integrate compilation database.
+## [2025-06-09 22:39 UTC] repo hygiene sweep [codex]
+- Installed dev dependencies and ran `pre-commit` – all hooks pass.
+- Reapplied `clang-format` across sources.
+- `clang-tidy` still fails (no compilation database).
+- Executed `make test` successfully; removed Python `__pycache__`.
+
+Next agent must:
+- Provide a compile_commands.json for clang-tidy and fix reported issues.

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -533,3 +533,18 @@ by: codex-agent-xyz
 - `python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt`
 - `pip install -r requirements-dev.txt && pytest --maxfail=1 --disable-warnings -q`
  main
+## [2025-06-09 22:34 UTC] repo hygiene sweep [codex]
+### Changes
+- Formatted sources via clang-format and black.
+- Adjusted tests/python/test_audit_cli.py formatting.
+### Tests
+- `pre-commit run --all-files`
+- `make test`
+## [2025-06-09 22:39 UTC] repo hygiene sweep [codex]
+### Changes
+- Re-ran `clang-format` and `pre-commit` after installing dev tools.
+- Removed stray Python `__pycache__` created during tests.
+### Tests
+- `pre-commit run --all-files`
+- `make test`
+- `clang-tidy src/*.c subsystems/*/*.c` *(fails: no compilation database)*

--- a/tests/python/test_audit_cli.py
+++ b/tests/python/test_audit_cli.py
@@ -11,18 +11,24 @@ class AuditCliTest(unittest.TestCase):
             os.remove("AOS-CHECKLIST.log")
 
     def test_clear_and_show(self):
-        res = subprocess.run(["python3", SCRIPT, "clear"], capture_output=True, text=True)
+        res = subprocess.run(
+            ["python3", SCRIPT, "clear"], capture_output=True, text=True
+        )
         self.assertEqual(res.returncode, 0)
         res = subprocess.run(["python3", SCRIPT, "log"], capture_output=True, text=True)
         self.assertEqual(res.stdout.strip(), "")
 
     def test_rollback_invalid(self):
-        res = subprocess.run([
-            "python3",
-            SCRIPT,
-            "rollback",
-            "deadbeef",
-        ], capture_output=True, text=True)
+        res = subprocess.run(
+            [
+                "python3",
+                SCRIPT,
+                "rollback",
+                "deadbeef",
+            ],
+            capture_output=True,
+            text=True,
+        )
         self.assertNotEqual(res.returncode, 0)
         self.assertIn("rollback failed", res.stderr)
 


### PR DESCRIPTION
## Summary
- run pre-commit and clang-format
- update logs
- fix Python formatting for audit_cli test
- rerun pre-commit and make test after installing dev deps

## Testing
- `pre-commit run --all-files`
- `make test`
- `clang-tidy src/*.c subsystems/*/*.c` *(fails: no compilation database)*

------
https://chatgpt.com/codex/tasks/task_e_684760f99f58832597bd8f6823010abe