### PR TITLE
Cleanup meta logs and formatting

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -291,15 +291,16 @@ Next agent must:
 
 
 ## Active Baton Passes
-- Provide compile_commands.json for clang-tidy, fix warnings and restore failing builds (`host`, `branch-net`).
-- Expand ext2 filesystem backend and add persistence tests.
-- Flesh out device and security subsystem APIs and documentation.
+- Generate `compile_commands.json` via `make compdb` and resolve clang-tidy warnings; ensure host and branch-net builds succeed.
+- Expand ext2 filesystem backend with persistence tests.
+- Flesh out device and security subsystem APIs and documentation; review subsystem comments.
 - Review network branch sync for race conditions and add tests.
 - Improve AI error handling and provide offline mock responses.
-- Integrate policy engine with network layer and credential storage plan.
-- Extend WASM runtime with capability enforcement.
-- Continue expanding subsystem READMEs and overall developer docs.
-- Verify pre-commit hooks run without authentication prompts in CI.
+- Integrate policy engine with the network layer and credential storage.
+- Extend WASM runtime with capability enforcement and expand checkpoint delta handling.
+- Expand tests across subsystems and verify pre-commit hooks run in CI without auth prompts; ensure fresh venv installs cover runtime scripts.
+- Address cppcheck warnings and integrate profiler with logging.
+- Monitor CODE_OF_CONDUCT compliance and overall CI stability.
 - Keep ROADMAP.md updated as milestones progress.
 
 ## Archive
@@ -382,5 +383,12 @@ Next agent must:
 - Added MIT license summary to README.
 - Introduced 'compdb' Makefile target to generate compile_commands.json.
 
-Next agent must:
-- Use the new compdb rule and address clang-tidy warnings.
+
+## [2025-06-10 00:10 UTC] meta sweep [codex]
+- Ran clang-format and black on sources.
+- Generated compile_commands.json via `make compdb`.
+- clang-tidy still reports many warnings and errors (see /tmp/clang_tidy.log).
+- Executed `make test-unit`, `make test-integration`, and `pytest -q tests/python` successfully.
+- Installed npm packages and ran ESLint with no issues.
+- Removed `__pycache__` and npm lock file.
+

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -575,3 +575,16 @@ by: codex-agent-xyz
 - `pre-commit run --all-files`
 - `make test-unit`
 - `make test-integration`
+
+## [2025-06-10 00:10 UTC] meta sweep [codex]
+### Changes
+- Ran clang-format and black across sources.
+- Generated compile_commands.json via make compdb.
+- No lint errors; clang-tidy still fails.
+- Updated AGENT.md baton list.
+### Tests
+- `pre-commit run --all-files`
+- `make test-unit`
+- `make test-integration`
+- `pytest -q tests/python`
+

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -9,7 +9,8 @@ static clock_t start_time;
 
 void profiler_start(void) { start_time = clock(); }
 
-void profiler_stop(void) { /* noop for now */ }
+void profiler_stop(void) { /* noop for now */
+}
 
 void profiler_report(const char *label) {
     clock_t end = clock();

--- a/subsystems/fs/fs.c
+++ b/subsystems/fs/fs.c
@@ -45,7 +45,7 @@ void fs_ls(void) {
 
 int fs_mkdir(const char *name) { return current->mkdir ? current->mkdir(name) : -1; }
 
-int fs_delete(const char *name) { return current->delete ? current->delete(name) : -1; }
+int fs_delete(const char *name) { return current->delete ? current->delete (name) : -1; }
 
 /* --- ramfs backend (existing in-memory demo) --- */
 #define MAX_FILES 16


### PR DESCRIPTION
## Summary
- update agent log and consolidate baton list
- run clang-format/black/flake8/eslint
- generate compile_commands.json and log clang-tidy errors
- clean up small formatting issues

## Testing
- `pre-commit run --all-files`
- `make test-unit`
- `make test-integration`
- `pytest -q tests/python`
- `clang-tidy src/*.c subsystems/*/*.c -p compile_commands.json` *(fails: warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_68477740b58c83258948444fcab1c787