### PR TITLE
Phase 0 documentation and test skeletons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,18 @@ tests/c/test_plugin.c src/plugin_loader.c src/plugin_supervisor.c src/wasm_runti
 	tests/c/test_policy.c src/policy.c src/logging.c src/error.c \
 	-o build/tests/test_policy
 	@./build/tests/test_policy
+	gcc --coverage -Isubsystems/dev -Iinclude \
+	tests/c/test_dev.c subsystems/dev/dev.c src/logging.c src/error.c \
+	-o build/tests/test_dev
+	@./build/tests/test_dev
+	gcc --coverage -Isubsystems/security -Iinclude \
+	tests/c/test_security.c subsystems/security/security.c src/logging.c src/error.c \
+	-o build/tests/test_security
+	@./build/tests/test_security
+	gcc --coverage -Iinclude \
+	tests/c/test_ui.c src/logging.c src/error.c -lncurses \
+	-o build/tests/test_ui
+	@./build/tests/test_ui
 	@python3 -m pytest -q tests/python
 		
 test-integration:

--- a/PROJECT_LAYOUT.md
+++ b/PROJECT_LAYOUT.md
@@ -2,18 +2,33 @@
 
 This document outlines the purpose of each top-level directory in the AOS repository.
 
-- `apps_src/` – sample applications built as part of the userland demos.
-- `bare_metal_os/` – minimal kernel sources and boot files for bare metal targets.
-- `boot/` – build artifacts and scripts related to bootloader construction.
-- `docs/` – project documentation. Legacy files are kept under `docs/archive/`.
-- `examples/` – small scripts and programs demonstrating subsystem usage.
-- `include/` – public C headers shared across host and kernel builds.
-- `scripts/` – utility scripts used during development and CI.
-- `src/` – host-side entry points and shared helpers.
-- `subsystems/` – core modules such as memory, filesystem and networking.
-- `tests/` – unit and integration tests run by the CI pipeline.
-- `ui/` – graphical and web user interfaces.
+| Path | Subsystem | Phase | Status |
+|------|-----------|-------|--------|
+| `apps_src/` | host | 6 | ✔ |
+| `bare_metal_os/` | kernel | 1 | ✔ |
+| `boot/` | kernel | 1 | ✔ |
+| `docs/` | tooling | 0 | ✔ |
+| `examples/` | host | 7 | ✔ |
+| `include/` | kernel | 1 | ✔ |
+| `scripts/` | tooling | 0 | ✔ |
+| `src/` | host | 3 | ✔ |
+| `subsystems/` | host | 2 | ✔ |
+| `tests/` | tooling | 0 | ✔ |
+| `ui/` | UI | 9 | ✔ |
+| `Makefile` | tooling | 0 | ✔ |
+| `AGENT.md` | tooling | 0 | ✔ |
+| `PATCHLOG.md` | tooling | 0 | ✔ |
+| `PROJECT_LAYOUT.md` | tooling | 0 | ✔ |
+| `ROADMAP.md` | tooling | 0 | ✔ |
+| `README.md` | tooling | 0 | ✔ |
+| `SECURITY.md` | tooling | 0 | ✔ |
+| `CODE_OF_CONDUCT.md` | tooling | 0 | ✔ |
+| `CONTRIBUTING.md` | tooling | 0 | ✔ |
+| `LICENSE` | tooling | 0 | ✔ |
+| `mappings.json` | tooling | 0 | ✔ |
+| `pyproject.toml` | tooling | 0 | ✔ |
+| `requirements.txt` | tooling | 0 | ✔ |
+| `requirements-dev.txt` | tooling | 0 | ✔ |
 
-Other files at the repository root include build configuration (`Makefile`),
-development logs (`AGENT.md`, `PATCHLOG.md`), and the `ROADMAP.md` describing
-planned work.
+Other files at the repository root include build artifacts under `build/` and
+generated logs such as `AOS-CHECKLIST.log`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,20 @@
 
 Major milestones are tracked by version tags in git.
 
+| Phase | Description | Status |
+|-------|-------------|-------|
+| 0 | Repo inventory, docs, coverage baseline | ✔ |
+| 1 | Kernel–host boundary and IPC | ⚪ |
+| 2 | Memory management and snapshotting | ⚪ |
+| 3 | Branch & process table | ⚪ |
+| 4 | Filesystem & devices | ⚪ |
+| 5 | Security & policy engine | ⚪ |
+| 6 | REPL and scripting | ⚪ |
+| 7 | Plugin system & WASM | ⚪ |
+| 8 | AI integration | ⚪ |
+| 9 | UI (web/native/cli) | ⚪ |
+| 10 | Federation & distributed | ⚪ |
+
 ## Current Sprint Goals
 - Extend ext2 tests for persistence.
 - Hook the security subsystem into the WASM runtime for capability checks.

--- a/tests/c/test_dev.c
+++ b/tests/c/test_dev.c
@@ -1,0 +1,8 @@
+#include "dev.h"
+#include <assert.h>
+int main(void) {
+    driver_register("dummy");
+    driver_list();
+    assert(1 && "dev skeleton");
+    return 0;
+}

--- a/tests/c/test_security.c
+++ b/tests/c/test_security.c
@@ -1,0 +1,7 @@
+#include "security.h"
+#include <assert.h>
+int main(void) {
+    security_init();
+    assert(check_capability("none") == 0);
+    return 0;
+}

--- a/tests/c/test_ui.c
+++ b/tests/c/test_ui.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main(void) {
+    puts("ui skeleton");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- document every top level path with subsystem, phase and status
- outline phase progress in `ROADMAP.md`
- add missing skeleton tests for dev, security and ui subsystems
- hook new tests into `make test`

## Testing
- `make test`
- `pytest -q tests/python`
- `./scripts/qemu_smoke.sh x86_64` *(fails: `Illegal option -o pipefail`)*


------
https://chatgpt.com/codex/tasks/task_e_684794642c088325a934664f854fe210