### PR TITLE
Add minimal S-expr VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SUBSYSTEM_DIRS := subsystems/memory subsystems/fs subsystems/ai subsystems/branc
 HOST_SRCS := \
 src/main.c src/repl.c src/interpreter.c src/branch_manager.c src/ui_graph.c \
 src/branch_vm.c src/plugin_loader.c src/plugin_supervisor.c src/wasm_runtime.c \
+src/lang_vm.c \
 src/branch_net.c src/ai_syscall.c src/aicell.c src/checkpoint.c src/policy.c \
 src/memory.c src/app_runtime.c src/config.c src/logging.c src/error.c \
 src/generated/command_map.c src/generated/commands.c \
@@ -271,6 +272,11 @@ tests/c/test_plugin.c src/plugin_loader.c src/plugin_supervisor.c src/wasm_runti
 	tests/c/test_ui.c src/logging.c src/error.c -lncurses \
 	-o build/tests/test_ui
 	@./build/tests/test_ui
+	gcc --coverage -Iinclude -Isubsystems/ai \
+	tests/lang_test.c src/lang_vm.c src/branch_manager.c \
+	subsystems/ai/ai.c src/ai_syscall.c src/logging.c src/error.c -lcurl \
+	-o build/tests/test_lang
+	@./build/tests/test_lang
 	@python3 -m pytest --cov=./ -q tests/python
 	
 test-integration:

--- a/examples/hello.aos
+++ b/examples/hello.aos
@@ -1,0 +1,2 @@
+(print "Hello, AOS!")
+(exit)

--- a/include/lang_vm.h
+++ b/include/lang_vm.h
@@ -1,0 +1,6 @@
+#ifndef LANG_VM_H
+#define LANG_VM_H
+
+int lang_vm_run_file(const char *path);
+
+#endif // LANG_VM_H

--- a/src/lang_vm.c
+++ b/src/lang_vm.c
@@ -1,0 +1,97 @@
+#include "lang_vm.h"
+#include "ai.h"
+#include "branch.h"
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *skip_ws(const char *p) {
+    while (p && *p && isspace((unsigned char)*p))
+        p++;
+    return p;
+}
+
+static const char *parse_ident(const char *p, char *out, size_t n) {
+    size_t i = 0;
+    while (*p && !isspace((unsigned char)*p) && *p != ')' && i + 1 < n)
+        out[i++] = *p++;
+    out[i] = '\0';
+    return p;
+}
+
+static const char *parse_string(const char *p, char *out, size_t n) {
+    if (*p != '"')
+        return NULL;
+    p++;
+    size_t i = 0;
+    while (*p && *p != '"' && i + 1 < n)
+        out[i++] = *p++;
+    out[i] = '\0';
+    if (*p != '"')
+        return NULL;
+    return p + 1;
+}
+
+static int exec_expr(const char *op, const char *arg) {
+    if (strcmp(op, "print") == 0) {
+        printf("%s\n", arg);
+    } else if (strcmp(op, "branch-create") == 0 || strcmp(op, "branch_create") == 0) {
+        bm_create(arg);
+    } else if (strcmp(op, "ai-query") == 0 || strcmp(op, "ai_query") == 0) {
+        const char *resp = ai_reply(arg);
+        printf("%s\n", resp);
+    } else if (strcmp(op, "exit") == 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static int vm_run(const char *src) {
+    const char *p = src;
+    char op[32];
+    char arg[256];
+    while ((p = strchr(p, '('))) {
+        p++;
+        p = skip_ws(p);
+        p = parse_ident(p, op, sizeof(op));
+        p = skip_ws(p);
+        arg[0] = '\0';
+        if (*p == '"') {
+            const char *np = parse_string(p, arg, sizeof(arg));
+            if (!np)
+                return -1;
+            p = np;
+        } else if (*p && *p != ')') {
+            p = parse_ident(p, arg, sizeof(arg));
+        }
+        const char *close = strchr(p, ')');
+        if (!close)
+            break;
+        p = close + 1;
+        if (exec_expr(op, arg))
+            break;
+    }
+    return 0;
+}
+
+int lang_vm_run_file(const char *path) {
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return -1;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(sz + 1);
+    if (!buf) {
+        fclose(f);
+        return -1;
+    }
+    fread(buf, 1, sz, f);
+    buf[sz] = '\0';
+    fclose(f);
+    int rc = vm_run(buf);
+    free(buf);
+    return rc;
+}
+

--- a/tests/lang_test.c
+++ b/tests/lang_test.c
@@ -1,0 +1,23 @@
+#include "lang_vm.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *buf = NULL;
+    size_t size = 0;
+    FILE *mem = open_memstream(&buf, &size);
+    FILE *orig = stdout;
+    stdout = mem;
+    int rc = lang_vm_run_file("examples/hello.aos");
+    fflush(stdout);
+    stdout = orig;
+    fclose(mem);
+    assert(rc == 0);
+    assert(buf != NULL);
+    assert(strcmp(buf, "Hello, AOS!\n") == 0);
+    free(buf);
+    printf("lang vm tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add tiny VM implementation for S-expression scripts
- compile VM in host build and provide simple script example
- exercise VM via new unit test

## Testing
- `pre-commit run --files Makefile examples/hello.aos include/lang_vm.h src/lang_vm.c tests/lang_test.c`
- `make test-unit`
- `make test-integration`

------
https://chatgpt.com/codex/tasks/task_e_6847b285ddd08325850ad42f2950a5e2