### PR TITLE
feat(traps): add IDT setup & default page-fault/syscall handler

### DIFF
--- a/bare_metal_os/Makefile
+++ b/bare_metal_os/Makefile
@@ -10,19 +10,21 @@ LDFLAGS = -T kernel.ld -m elf_i386 -z separate-code
 
 all: bootloader.bin kernel.bin aos.bin
 	
-kernel.bin: kernel.c memory.c fs.c branch.c ai_trigger.c interpreter/command_interpreter.c ../src/generated/commands.c ../src/generated/command_map.c config_stub.c ../logging.c ../error.c
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c kernel.c -o kernel.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c memory.c -o memory.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c fs.c -o fs.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c branch.c -o branch.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ai_trigger.c -o ai_trigger.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c interpreter/command_interpreter.c -o command_interpreter.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../src/generated/commands.c -o commands.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../src/generated/command_map.c -o command_map.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c config_stub.c -o config.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../logging.c -o logging.o
-       $(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../error.c -o error.o
-       $(LD) $(LDFLAGS) kernel.o memory.o fs.o branch.o ai_trigger.o command_interpreter.o commands.o command_map.o config.o logging.o error.o -o kernel.elf
+kernel.bin: kernel.c memory.c fs.c branch.c ai_trigger.c idt.c traps.c interpreter/command_interpreter.c ../src/generated/commands.c ../src/generated/command_map.c config_stub.c ../logging.c ../error.c
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c kernel.c -o kernel.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c memory.c -o memory.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c fs.c -o fs.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c branch.c -o branch.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ai_trigger.c -o ai_trigger.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c idt.c -o idt.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c traps.c -o traps.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c interpreter/command_interpreter.c -o command_interpreter.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../src/generated/commands.c -o commands.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../src/generated/command_map.c -o command_map.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c config_stub.c -o config.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../logging.c -o logging.o
+	$(CC) $(CFLAGS) -I.. -I../include -I../src/generated -c ../error.c -o error.o
+	$(LD) $(LDFLAGS) kernel.o memory.o fs.o branch.o ai_trigger.o idt.o traps.o command_interpreter.o commands.o command_map.o config.o logging.o error.o -o kernel.elf
 	objcopy -O binary kernel.elf kernel.bin
 
 

--- a/bare_metal_os/idt.c
+++ b/bare_metal_os/idt.c
@@ -1,0 +1,47 @@
+#include <stdint.h>
+#include "idt.h"
+#include "traps.h"
+
+typedef struct {
+    uint16_t offset_low;
+    uint16_t selector;
+    uint8_t zero;
+    uint8_t type_attr;
+    uint16_t offset_high;
+} __attribute__((packed)) idt_entry_t;
+
+typedef struct {
+    uint16_t limit;
+    uint32_t base;
+} __attribute__((packed)) idt_ptr_t;
+
+static idt_entry_t idt[256];
+static idt_ptr_t idt_desc;
+
+static void idt_set_gate(int n, void (*handler)(void)) {
+    uint32_t addr = (uint32_t)handler;
+    idt[n].offset_low = addr & 0xFFFF;
+    idt[n].selector = 0x08; /* code segment */
+    idt[n].zero = 0;
+    idt[n].type_attr = 0x8E; /* present, dpl=0, 32-bit interrupt gate */
+    idt[n].offset_high = (addr >> 16) & 0xFFFF;
+}
+
+void idt_init(void) {
+    for (int i = 0; i < 256; i++) {
+        idt[i].offset_low = 0;
+        idt[i].selector = 0;
+        idt[i].zero = 0;
+        idt[i].type_attr = 0;
+        idt[i].offset_high = 0;
+    }
+
+    idt_set_gate(14, (void (*)(void))isr_default);
+    idt_set_gate(0x80, (void (*)(void))isr_default);
+
+    idt_desc.limit = sizeof(idt) - 1;
+    idt_desc.base = (uint32_t)&idt;
+
+    __asm__ volatile("lidt %0" : : "m"(idt_desc));
+}
+

--- a/bare_metal_os/idt.h
+++ b/bare_metal_os/idt.h
@@ -1,0 +1,6 @@
+#ifndef AOS_IDT_H
+#define AOS_IDT_H
+
+void idt_init(void);
+
+#endif

--- a/bare_metal_os/kernel.c
+++ b/bare_metal_os/kernel.c
@@ -3,6 +3,8 @@
 #include "error.h"
 #include "logging.h"
 #include "ipc.h"
+#include "idt.h"
+#include "traps.h"
 #include <stdint.h>
 
 /* Boot entry points provided by assembly stub. */
@@ -40,12 +42,14 @@ static void kernel_init(void) {
     config_load_default();
 }
 
-void main(void) {
-    /* Entry called by bootloader. Start subsystems and drop into REPL. */
+static void kernel_main(void) {
+    idt_init();
     kernel_init();
     process_ipc();
     repl();
 }
+
+void main(void) { kernel_main(); }
 
 void _start(void) {
     /* Minimal bootstrap that calls main and halts when it returns. */

--- a/bare_metal_os/traps.c
+++ b/bare_metal_os/traps.c
@@ -1,0 +1,34 @@
+#include "traps.h"
+#include <stdint.h>
+
+static inline void outb(uint16_t p, uint8_t v) { asm volatile("outb %0,%1" ::"a"(v), "Nd"(p)); }
+static inline uint8_t inb(uint16_t p) { uint8_t r; asm volatile("inb %1,%0" : "=a"(r) : "Nd"(p)); return r; }
+
+static int serial_empty(void) { return inb(0x3F8 + 5) & 0x20; }
+static void serial_write(char a) { while (!serial_empty()) ; outb(0x3F8, a); }
+static void serial_print(const char *s) { while (*s) serial_write(*s++); }
+
+static void print_hex(uint32_t v) {
+    char hex[8];
+    serial_print("0x");
+    for (int i = 0; i < 8; i++) {
+        int d = (v >> ((7 - i) * 4)) & 0xF;
+        hex[i] = d < 10 ? '0' + d : 'a' + d - 10;
+        serial_write(hex[i]);
+    }
+}
+
+void isr_default(registers_t *r) {
+    uint32_t cr2;
+    __asm__ volatile("mov %%cr2, %0" : "=r"(cr2));
+    serial_print("Page fault at ");
+    print_hex(cr2);
+    serial_print(" RIP=");
+    print_hex(r->rip);
+    serial_print(" RSP=");
+    print_hex(r->rsp);
+    serial_print("\n");
+    for (;;)
+        __asm__("hlt");
+}
+

--- a/bare_metal_os/traps.h
+++ b/bare_metal_os/traps.h
@@ -1,0 +1,16 @@
+#ifndef AOS_TRAPS_H
+#define AOS_TRAPS_H
+
+#include <stdint.h>
+
+typedef struct registers {
+    uint32_t rip;
+    uint32_t cs;
+    uint32_t rflags;
+    uint32_t rsp;
+    uint32_t ss;
+} registers_t;
+
+void isr_default(registers_t *r) __attribute__((interrupt));
+
+#endif

--- a/tests/trap_test.c
+++ b/tests/trap_test.c
@@ -1,0 +1,4 @@
+int main(void) {
+    __asm__("mov $1, %eax\n\txor %eax, %eax\n\tdiv %eax");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add IDT initialization for bare-metal kernel
- implement simple default ISR that prints page fault info
- expose new headers for traps and IDT
- compile new modules in kernel build
- provide trap test harness program

## Testing
- `make test` *(fails: `pytest` couldn't recognize `--cov` option)*

------
https://chatgpt.com/codex/tasks/task_e_6847b3776ae8832599001b6507c1fe48