### PR TITLE
Use credential vault for AI backend

### DIFF
--- a/scripts/ai_backend.py
+++ b/scripts/ai_backend.py
@@ -21,12 +21,16 @@ def main():
         print(f"[mock-ai] response to: {prompt}")
         return 0
 
-    key = get_api_key("openai")
-    if not key:
-        print("ERROR: no AI credential for 'openai' \u2014 run `ai-cred set --service=openai <key>`", file=sys.stderr)
-        return 2
+    try:
+        key = get_api_key("openai")
+    except KeyError:
+        print(
+            "ERROR: no AI credential for 'openai' \u2014 run `ai-cred set --service=openai <key>`",
+            file=sys.stderr,
+        )
+        return 1
     if openai is None:
-        print("openai package missing", file=sys.stderr)
+        print("ERROR: openai package missing", file=sys.stderr)
         return 2
     client = openai.OpenAI(api_key=key)
     prompt = sys.argv[1]
@@ -37,7 +41,7 @@ def main():
         )
         print(resp.choices[0].message.content.strip())
     except Exception as e:
-        print(f"error: {e}", file=sys.stderr)
+        print(f"ERROR: {e}", file=sys.stderr)
         return 3
     return 0
 

--- a/scripts/ai_cred_client.py
+++ b/scripts/ai_cred_client.py
@@ -1,17 +1,28 @@
+"""Client helper to fetch AI credentials from the vault daemon."""
+
+from __future__ import annotations
+
 import json
 import os
 import socket
 
+
 SOCK_PATH = os.environ.get("AICRED_SOCK", "/run/ai-cred.sock")
 
 
-def get_api_key(service):
-    try:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
-            s.connect(SOCK_PATH)
-            s.sendall(json.dumps({"method": "get", "params": {"service": service}}).encode())
-            data = s.recv(1024)
-        resp = json.loads(data.decode())
-        return resp.get("result")
-    except Exception:
-        return None
+def get_api_key(service: str) -> str:
+    """Return API key for *service* via ``ai_cred_manager``.
+
+    Raises ``KeyError`` if no credential is stored.
+    """
+
+    req = json.dumps({"method": "get", "params": {"service": service}}).encode()
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+        s.connect(SOCK_PATH)
+        s.sendall(req)
+        data = s.recv(1024)
+
+    resp = json.loads(data.decode())
+    if not resp.get("result"):
+        raise KeyError(service)
+    return resp["result"]

--- a/tests/python/test_ai_backend.py
+++ b/tests/python/test_ai_backend.py
@@ -1,19 +1,103 @@
 import os
-import subprocess
+import sys
 import unittest
+from types import SimpleNamespace
+import unittest.mock
+import importlib
 
 SCRIPT = os.path.join("scripts", "ai_backend.py")
 
 
 class AiBackendTest(unittest.TestCase):
+    def setUp(self):
+        path = os.path.join(os.getcwd(), "scripts")
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
     def test_offline(self):
-        env = os.environ.copy()
-        env["AOS_AI_OFFLINE"] = "1"
-        res = subprocess.run(
-            ["python3", SCRIPT, "hi"], capture_output=True, text=True, env=env
+        mod = importlib.reload(importlib.import_module("ai_backend"))
+        os.environ["AOS_AI_OFFLINE"] = "1"
+        sys.argv = ["ai_backend.py", "hi"]
+        try:
+            self.assertEqual(mod.main(), 0)
+        finally:
+            del os.environ["AOS_AI_OFFLINE"]
+
+    def test_success(self):
+        mod = importlib.reload(importlib.import_module("ai_backend"))
+
+        def fake_get(_svc):
+            return "k"
+
+        fake_openai = SimpleNamespace(
+            OpenAI=lambda api_key: SimpleNamespace(
+                chat=SimpleNamespace(
+                    completions=SimpleNamespace(
+                        create=lambda **_: SimpleNamespace(
+                            choices=[
+                                SimpleNamespace(message=SimpleNamespace(content="ok"))
+                            ]
+                        )
+                    )
+                )
+            )
         )
-        self.assertEqual(res.returncode, 0)
-        self.assertIn("[mock-ai]", res.stdout)
+
+        with unittest.mock.patch.object(
+            mod, "get_api_key", fake_get
+        ), unittest.mock.patch.object(mod, "openai", fake_openai):
+            sys.argv = ["ai_backend.py", "hi"]
+            self.assertEqual(mod.main(), 0)
+
+    def test_no_args(self):
+        mod = importlib.reload(importlib.import_module("ai_backend"))
+        sys.argv = ["ai_backend.py"]
+        self.assertEqual(mod.main(), 1)
+
+    def test_openai_missing(self):
+        mod = importlib.reload(importlib.import_module("ai_backend"))
+
+        def fake_get(_):
+            return "k"
+
+        with unittest.mock.patch.object(mod, "get_api_key", fake_get):
+            mod.openai = None
+            sys.argv = ["ai_backend.py", "hi"]
+            self.assertEqual(mod.main(), 2)
+
+    def test_openai_error(self):
+        mod = importlib.reload(importlib.import_module("ai_backend"))
+
+        def fake_get(_svc):
+            return "k"
+
+        class BadClient:
+            def __init__(self, api_key):
+                pass
+
+            class chat:
+                class completions:
+                    @staticmethod
+                    def create(**_):
+                        raise RuntimeError("boom")
+
+        fake_openai = SimpleNamespace(OpenAI=BadClient)
+
+        with unittest.mock.patch.object(
+            mod, "get_api_key", fake_get
+        ), unittest.mock.patch.object(mod, "openai", fake_openai):
+            sys.argv = ["ai_backend.py", "hi"]
+            self.assertEqual(mod.main(), 3)
+
+    def test_missing_key(self):
+        mod = importlib.reload(importlib.import_module("ai_backend"))
+
+        def bad_get(_svc):
+            raise KeyError("openai")
+
+        with unittest.mock.patch.object(mod, "get_api_key", bad_get):
+            sys.argv = ["ai_backend.py", "hi"]
+            self.assertEqual(mod.main(), 1)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_ai_cred_client.py
+++ b/tests/python/test_ai_cred_client.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest import mock
+
+from scripts import ai_cred_client
+
+
+class AiCredClientTest(unittest.TestCase):
+    def _mock_socket(self, response_bytes):
+        sock = mock.MagicMock()
+        sock.__enter__.return_value = sock
+        sock.recv.return_value = response_bytes
+        return sock
+
+    def test_get_api_key_success(self):
+        sock = self._mock_socket(b'{"result": "abc"}')
+        with mock.patch("socket.socket", return_value=sock):
+            key = ai_cred_client.get_api_key("openai")
+        self.assertEqual(key, "abc")
+        sock.connect.assert_called_once_with(ai_cred_client.SOCK_PATH)
+        sock.sendall.assert_called()
+
+    def test_get_api_key_missing(self):
+        sock = self._mock_socket(b'{"result": ""}')
+        with mock.patch("socket.socket", return_value=sock):
+            with self.assertRaises(KeyError):
+                ai_cred_client.get_api_key("openai")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fetch API keys from ai_cred_manager using `ai_cred_client.get_api_key`
- raise `KeyError` for missing credentials
- handle `KeyError` in `ai_backend` and exit with an error
- extend Python tests to cover new vault logic
- add dedicated tests for `ai_cred_client`
- address feedback on docstrings and error messages

## Testing
- `pre-commit run --files scripts/ai_backend.py scripts/ai_cred_client.py tests/python/test_ai_backend.py tests/python/test_ai_cred_client.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6847e8c45c388325b938326b48c8427d