### PR TITLE
Add agent orchestrator with timeout handling

### DIFF
--- a/scripts/agent_orchestrator.py
+++ b/scripts/agent_orchestrator.py
@@ -1,0 +1,77 @@
+"""Simple agent orchestrator with timeout and SSE status events."""
+
+import subprocess
+import queue
+import json
+from typing import Dict
+from flask import Response
+
+
+class _SSE:
+    """Minimal in-memory server-sent events helper."""
+
+    def __init__(self):
+        self._clients = []
+
+    def publish(self, data, event=None):
+        for q in list(self._clients):
+            q.put({"event": event, "data": data})
+
+    def stream(self):
+        def gen():
+            q = queue.Queue()
+            self._clients.append(q)
+            try:
+                while True:
+                    msg = q.get()
+                    if msg["event"]:
+                        yield f"event: {msg['event']}\n"
+                    yield f"data: {json.dumps(msg['data'])}\n\n"
+            finally:
+                self._clients.remove(q)
+
+        return Response(gen(), mimetype="text/event-stream")
+
+
+class AgentOrchestrator:
+    def __init__(self, logger):
+        self.logger = logger
+        self._sses: Dict[int, _SSE] = {}
+
+    def _get_sse(self, branch_id: int) -> _SSE:
+        if branch_id not in self._sses:
+            self._sses[branch_id] = _SSE()
+        return self._sses[branch_id]
+
+    def stream(self, branch_id: int):
+        return self._get_sse(branch_id).stream()
+
+    def launch(self, branch_id: int, agent_id: int, cmd, timeout: int = 60):
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            proc.wait(timeout=timeout)
+            exit_code = proc.returncode
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            exit_code = -1
+        out = proc.stdout.read() if proc.stdout else ""
+        err = proc.stderr.read() if proc.stderr else ""
+        result = out or err
+        status = "success" if exit_code == 0 else "failed"
+        event = {"agent_id": agent_id, "status": status}
+        if exit_code == -1:
+            event["error"] = "Timeout"
+        elif status == "failed":
+            event["error"] = f"Exit {exit_code}"
+        if result:
+            event["output"] = result.strip()
+        if status != "success":
+            self.logger.error("Agent %d failed: %s", agent_id, err.strip())
+        sse = self._get_sse(branch_id)
+        sse.publish(event, event="agent-status")
+        return event

--- a/scripts/branch_ui.py
+++ b/scripts/branch_ui.py
@@ -5,6 +5,7 @@ import os
 import queue
 import subprocess
 from flask import Flask, Response, jsonify, request, send_from_directory
+from .agent_orchestrator import AgentOrchestrator
 
 PORT = 8000
 BASE = os.path.dirname(os.path.abspath(__file__))
@@ -111,6 +112,7 @@ class BranchService:
 flask_sse = _SSE()
 app = Flask(__name__, static_folder=WEB_DIR, static_url_path="")
 service = BranchService(app.logger)
+agent_orch = AgentOrchestrator(app.logger)
 
 
 @app.route("/graph")
@@ -161,6 +163,11 @@ def merge_branch(bid):
 @app.route("/events")
 def events():
     return flask_sse.stream()
+
+
+@app.route("/branches/<int:bid>/agents")
+def branch_agents(bid):
+    return agent_orch.stream(bid)
 
 
 @app.route("/<path:path>")

--- a/scripts/tests/test_agent_orchestrator.py
+++ b/scripts/tests/test_agent_orchestrator.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+from scripts.agent_orchestrator import AgentOrchestrator
+
+
+class AgentOrchestratorTest(unittest.TestCase):
+    def setUp(self):
+        self.orch = AgentOrchestrator(mock.Mock())
+
+    def _script(self, content):
+        fd, path = tempfile.mkstemp(suffix=".py")
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.chmod(path, 0o755)
+        return path
+
+    def test_exit_failure(self):
+        script = self._script("import sys; sys.exit(1)")
+        with mock.patch("scripts.agent_orchestrator._SSE.publish") as publish:
+            self.orch.launch(1, 3, [sys.executable, script])
+            publish.assert_called()
+            args, kwargs = publish.call_args
+            self.assertEqual(kwargs.get("event"), "agent-status")
+            data = args[0]
+            self.assertEqual(data["status"], "failed")
+        os.remove(script)
+
+    def test_timeout(self):
+        script = self._script("import time; time.sleep(1)")
+        with mock.patch("scripts.agent_orchestrator._SSE.publish") as publish:
+            self.orch.launch(1, 4, [sys.executable, script], timeout=0.1)
+            publish.assert_called()
+            args, kwargs = publish.call_args
+            data = args[0]
+            self.assertEqual(data["status"], "failed")
+            self.assertEqual(data.get("error"), "Timeout")
+        os.remove(script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `AgentOrchestrator` for running agents with timeout and SSE updates
- expose `/branches/<id>/agents` SSE endpoint in `branch_ui`
- test orchestrator failure and timeout cases

## Testing
- `pre-commit run --files scripts/agent_orchestrator.py scripts/branch_ui.py scripts/tests/test_agent_orchestrator.py`
- `make test-unit` *(fails: Invalid requirement in requirements.txt)*
- `make test-integration` *(fails: Invalid requirement in requirements.txt)*
- `PYTHONPATH=. pytest -q scripts/tests/test_agent_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_6848130ec8388325b81657e1cdd47cd6