### PR TITLE
Implement binary branch list syscall

### DIFF
--- a/docs/ipc_protocol.md
+++ b/docs/ipc_protocol.md
@@ -83,12 +83,27 @@ structs but must keep the total size within one page.
 
 ### SYS_LIST_BRANCHES
 - **Request:** `{}`
-- **Response:**
+- **Kernel Response (binary):**
+  ```c
+  struct {
+      uint32_t count;
+      struct branch_info entries[count];
+  };
+  ```
+  where `branch_info` is:
+  ```c
+  struct branch_info {
+      uint32_t branch_id;
+      uint32_t parent_id;
+      uint32_t status;
+      uint64_t last_snapshot_id;
+  } __attribute__((packed));
+  ```
+- **Host JSON conversion:**
   ```json
   {
     "branches": [
-      { "branch_id": 1, "parent_id": 0, "status": "CREATED" },
-      { "branch_id": 2, "parent_id": 1, "status": "RUNNING" }
+      { "branch_id": 1, "parent_id": 0, "status": 1, "last_snapshot_id": 0 }
     ]
   }
   ```

--- a/include/ipc_protocol.h
+++ b/include/ipc_protocol.h
@@ -1,0 +1,12 @@
+#ifndef IPC_PROTOCOL_H
+#define IPC_PROTOCOL_H
+#include <stdint.h>
+
+struct branch_info {
+    uint32_t branch_id;
+    uint32_t parent_id;
+    uint32_t status;
+    uint64_t last_snapshot_id; /* 0 if none */
+} __attribute__((packed));
+
+#endif /* IPC_PROTOCOL_H */

--- a/src/branch_syscalls.c
+++ b/src/branch_syscalls.c
@@ -1,4 +1,6 @@
 #include "syscalls.h"
+#include "branch.h"
+#include "ipc_protocol.h"
 #include <errno.h>
 #include <string.h>
 
@@ -14,8 +16,30 @@ int sys_merge_branch(int branch_id) {
 }
 
 int sys_list_branches(char *out, size_t outsz) {
-    if (out && outsz)
-        out[0] = '\0';
-    /* TODO: implement */
-    return 0;
+    if (!out)
+        return -EFAULT;
+
+    Branch branches[MAX_BRANCHES];
+    int count = bm_list(branches);
+
+    size_t needed = sizeof(uint32_t) + (size_t)count * sizeof(struct branch_info);
+    if (outsz < needed)
+        return -EMSGSIZE;
+
+    uint32_t n = (uint32_t)count;
+    memcpy(out, &n, sizeof(n));
+    size_t off = sizeof(n);
+    for (int i = 0; i < count; i++) {
+        struct branch_info bi;
+        bi.branch_id = (uint32_t)branches[i].id;
+        bi.parent_id = (uint32_t)branches[i].parent;
+        if (strcmp(branches[i].state, "running") == 0)
+            bi.status = 1;
+        else
+            bi.status = 0;
+        bi.last_snapshot_id = 0;
+        memcpy(out + off, &bi, sizeof(bi));
+        off += sizeof(bi);
+    }
+    return (int)off;
 }


### PR DESCRIPTION
## Summary
- define `branch_info` packed struct for IPC
- implement `sys_list_branches` to serialize branches in binary
- convert list binary to JSON in `ipc_host`
- document new format in `ipc_protocol.md`
- add unit test covering branch list syscall

## Testing
- `pre-commit run --files include/ipc_protocol.h src/branch_syscalls.c src/ipc_host.c docs/ipc_protocol.md tests/branch_syscalls_test.c Makefile`
- `flake8`
- `make compdb`
- `clang-tidy -p compile_commands.json $(git ls-files '*.c') -- -Iinclude` *(fails: no checks enabled)*
- `make test-unit` *(fails: invalid requirement in requirements.txt)*
- `gcc -Iinclude -pthread tests/branch_syscalls_test.c src/syscall.c src/ipc_host.c src/branch_manager.c subsystems/branch/branch.c src/logging.c src/error.c -DIPC_HOST_LIBRARY -o /tmp/test_branch_syscalls && /tmp/test_branch_syscalls`
- `make test-integration` *(fails: invalid requirement in requirements.txt)*
- `pytest -q tests/python` *(fails: ModuleNotFoundError: scripts)*

------
https://chatgpt.com/codex/tasks/task_e_684812add4608325968605fc4a4b2e28