### PR TITLE
Add branch snapshot and delete features

### DIFF
--- a/docs/ipc_protocol.md
+++ b/docs/ipc_protocol.md
@@ -118,6 +118,16 @@ structs but must keep the total size within one page.
   { "snapshot_id": 43 }
   ```
 
+### SYS_DELETE_BRANCH
+- **Request:**
+  ```json
+  { "branch_id": 2 }
+  ```
+- **Response:**
+  ```json
+  { "result": "ok" }
+  ```
+
 ### Examples
 
 ```bash

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -8,10 +8,12 @@
 #define SYS_MERGE_BRANCH   0x31
 #define SYS_LIST_BRANCHES  0x32
 #define SYS_SNAPSHOT_BRANCH 0x33
+#define SYS_DELETE_BRANCH   0x34
 
 int sys_create_branch(void);
 int sys_merge_branch(int branch_id);
 int sys_list_branches(char *out, size_t outsz);
 uint64_t sys_snapshot_branch(unsigned int branch_id);
+int sys_delete_branch(unsigned int branch_id);
 
 #endif /* SYSCALLS_H */

--- a/scripts/tests/test_branch_ui.py
+++ b/scripts/tests/test_branch_ui.py
@@ -1,13 +1,14 @@
+import os
+import sys
 import json
 import unittest
 from unittest import mock
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
-
-from scripts import branch_ui
 from flask import Response
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+)  # noqa: E402
+from scripts import branch_ui  # noqa: E402
 
 
 class BranchUITest(unittest.TestCase):
@@ -46,6 +47,54 @@ class BranchUITest(unittest.TestCase):
         self.assertTrue(data["merged"])
         self.assertIn("detail", data)
         publish.assert_called_with({"branch_id": 1}, event="branch-merged")
+
+    @mock.patch("scripts.branch_ui.flask_sse.publish")
+    @mock.patch("scripts.branch_ui.kernel_ipc", side_effect=[1, 42])
+    @mock.patch("scripts.branch_ui.subprocess.Popen")
+    def test_snapshot_flow(self, popen, ipc, publish):
+        proc = mock.Mock()
+        proc.pid = 1
+        popen.return_value = proc
+        self.client.post("/branches")
+        res = self.client.post("/branches/1/snapshot")
+        data = json.loads(res.data)
+        self.assertEqual(data["snapshot_id"], 42)
+        res = self.client.get("/branches")
+        data = json.loads(res.data)
+        self.assertEqual(data[0]["last_snapshot_id"], 42)
+        publish.assert_called_with(
+            {"branch_id": 1, "snapshot_id": 42}, event="branch-snapshot"
+        )
+
+    @mock.patch("scripts.branch_ui.flask_sse.publish")
+    @mock.patch("scripts.branch_ui.kernel_ipc", side_effect=[1, 0])
+    @mock.patch("scripts.branch_ui.subprocess.Popen")
+    def test_delete_flow(self, popen, ipc, publish):
+        proc = mock.Mock()
+        proc.pid = 2
+        popen.return_value = proc
+        self.client.post("/branches")
+        res = self.client.delete("/branches/1")
+        data = json.loads(res.data)
+        self.assertTrue(data["success"])
+        res = self.client.get("/branches")
+        data = json.loads(res.data)
+        self.assertEqual(len(data), 0)
+        publish.assert_called_with({"branch_id": 1}, event="branch-deleted")
+
+    @mock.patch("scripts.branch_ui.kernel_ipc", return_value=-22)
+    def test_invalid_snapshot(self, ipc):
+        res = self.client.post("/branches/99/snapshot")
+        data = json.loads(res.data)
+        self.assertIn("error", data)
+        self.assertEqual(res.status_code, 400)
+
+    @mock.patch("scripts.branch_ui.kernel_ipc", return_value=-22)
+    def test_invalid_delete(self, ipc):
+        res = self.client.delete("/branches/99")
+        data = json.loads(res.data)
+        self.assertIn("error", data)
+        self.assertEqual(res.status_code, 400)
 
     @mock.patch(
         "scripts.branch_ui.flask_sse.stream",

--- a/src/ipc_host.c
+++ b/src/ipc_host.c
@@ -77,8 +77,20 @@ void ipc_host_handle(IpcRing *ring) {
             sys_snapshot_branch((unsigned int)req->branch_id);
         resp->retval = 0;
         break;
+    case SYS_DELETE_BRANCH: {
+        int rc = sys_delete_branch((unsigned int)req->branch_id);
+        if (rc < 0) {
+            snprintf(resp->data, sizeof(resp->data),
+                     "{ \"error\": \"invalid branch\", \"code\": %d }",
+                     -rc);
+            resp->retval = strlen(resp->data);
+        } else {
+            resp->retval = 0;
+            resp->data[0] = '\0';
+        }
+        break;
+    }
     case SYS_FORK_BRANCH:
-    case SYS_DELETE_BRANCH:
     case SYS_LIST_BRANCH:
         resp->retval = -ENOSYS;
         break;

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -98,3 +98,17 @@ uint64_t sys_snapshot_branch(unsigned int branch_id) {
         usleep(1000);
     return *(uint64_t *)ring->resp[idx].data;
 }
+
+int sys_delete_branch(unsigned int branch_id) {
+    if (!ring)
+        return -1;
+    size_t idx = ring->head % IPC_RING_SIZE;
+    SyscallRequest *req = &ring->req[idx];
+    memset(req, 0, sizeof(*req));
+    req->id = SYS_DELETE_BRANCH;
+    req->branch_id = (int32_t)branch_id;
+    ring->head++;
+    while (ring->tail <= idx)
+        usleep(1000);
+    return ring->resp[idx].retval;
+}

--- a/ui/api.js
+++ b/ui/api.js
@@ -15,3 +15,15 @@ export async function mergeBranch(id) {
   if (!resp.ok) throw new Error('failed to merge branch');
   return await resp.json();
 }
+
+export async function snapshotBranch(id) {
+  const resp = await fetch(`/branches/${id}/snapshot`, { method: 'POST' });
+  if (!resp.ok) throw new Error('failed to snapshot branch');
+  return await resp.json();
+}
+
+export async function deleteBranch(id) {
+  const resp = await fetch(`/branches/${id}`, { method: 'DELETE' });
+  if (!resp.ok) throw new Error('failed to delete branch');
+  return await resp.json();
+}


### PR DESCRIPTION
## Summary
- support SYS_DELETE_BRANCH syscall and wrappers
- implement snapshot/delete in branch_syscalls
- extend ipc_host to process delete syscall
- expose snapshot and delete via branch_ui HTTP API
- update UI to add checkpoint/delete controls
- document new IPC schemas
- test snapshot and delete HTTP flows

## Testing
- `pre-commit run --files docs/ipc_protocol.md include/syscalls.h scripts/branch_ui.py scripts/tests/test_branch_ui.py src/branch_syscalls.c src/ipc_host.c src/syscall.c ui/api.js ui/app.js`
- `make test-unit`
- `make test-integration`
- `pytest -q tests/python`

------
https://chatgpt.com/codex/tasks/task_e_6848b34dd5bc8325a535b20e370013ec