### PR TITLE
Implement hunk-level AI merge

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -479,3 +479,13 @@ Next agent must:
 - Expand audit coverage across subsystems.
 ## [2025-06-10 09:00 UTC] merge hunk streamer [codex]
 - Added streaming merge_ai with hunk-based prompts and tests.
+
+## [2025-06-10 12:30 UTC] diff hunk merging [codex]
+- Added MAX_HUNK_SIZE limit and combined diff generation.
+- Hunks now split on file headers and @@ markers.
+- LLM failures mark hunks with CONFLICT blocks.
+- Added tests for hunk splitting and fallback.
+- Documented algorithm in docs/merge_ai.md.
+
+Next agent must:
+- Expand audit coverage across subsystems.

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -711,3 +711,15 @@ Next agent must:
 - `make test-unit`
 - `make test-integration`
 - `pytest -q tests/python/test_aos_audit.py`
+
+## [2025-06-10 12:30 UTC] diff hunk merging [codex]
+### Changes
+- Added MAX_HUNK_SIZE and 3-way diff support in merge_ai.py.
+- Split hunks by file headers and markers with logging.
+- Conflicts are wrapped when the LLM fails.
+- Added docs/merge_ai.md and updated docs index.
+### Tests
+- `pre-commit run --files scripts/merge_ai.py tests/python/test_merge_ai.py docs/merge_ai.md docs/README.md AGENT.md PATCHLOG.md`
+- `make test-unit`
+- `make test-integration`
+- `pytest -q tests/python/test_merge_ai.py`

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory contains additional guides for AOS.
 - `command_flow.md` – REPL command dispatch diagram.
 - `ci_cd.md` – CI/CD automation overview.
 - `generate_mappings.md` – mapping generator usage.
+- `merge_ai.md` – hunk-based AI merge helper.
 - `archive/` – legacy command mapping files kept for reference.
 
 Refer to [../AGENT.md](../AGENT.md) and [../PATCHLOG.md](../PATCHLOG.md) for development history.

--- a/docs/merge_ai.md
+++ b/docs/merge_ai.md
@@ -1,0 +1,26 @@
+# merge_ai Helper
+
+The `merge_ai.py` script performs an LLM-assisted three-way merge.
+
+## Hunk-based algorithm
+
+1. A combined unified diff is generated with
+   `git diff --no-prefix --unified=0 BASE MAIN BRANCH`.
+2. The diff is segmented into hunks at each `diff --git` header or `@@` marker.
+   Each hunk is at most `MAX_HUNK_SIZE` bytes (4096 by default).
+3. Every hunk is sent to the LLM with the prompt:
+
+   ```
+   Resolve this diff hunk between MAIN, BASE, and BRANCH. Return a valid patch snippet.
+   ```
+4. If the response does not apply cleanly, the original hunk is wrapped with
+   conflict markers:
+
+   ```
+   <<<<< CONFLICT
+   [original hunk]
+   >>>>>
+   ```
+5. The resulting snippets are concatenated to form the final patch. The script
+   logs the size and processing time of each hunk.
+


### PR DESCRIPTION
## Summary
- improve merge_ai.py to process unified diffs hunk by hunk
- add failing-hunk fallback and logging
- create tests for hunk splitting and LLM failure cases
- document the hunk algorithm

## Testing
- `pre-commit run --files AGENT.md PATCHLOG.md docs/README.md docs/merge_ai.md scripts/merge_ai.py tests/python/test_merge_ai.py`
- `make test-unit`
- `make test-integration`
- `pytest -q tests/python/test_merge_ai.py`


------
https://chatgpt.com/codex/tasks/task_e_6848b5bd1be48325bcdb339c6c075804