### PR TITLE
Add verify_all script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           files: coverage.lcov
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: RedactedCoder23/AOS
+      - name: Verify one-shot script
+        run: ./verify_all.sh
 
   sanitize-build:
     runs-on: ubuntu-latest

--- a/AGENT.md
+++ b/AGENT.md
@@ -501,3 +501,10 @@ Next agent must:
 
 Next agent must:
 - Expand audit coverage across subsystems.
+
+## [2025-06-11 03:00 UTC] verify-all script [codex]
+- Added verify_all.sh to run build, tests and demo smoke tests.
+- Hooked script into CI workflow and documented usage.
+
+Next agent must:
+- Expand audit coverage across subsystems.

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ CFLAGS := -Wall -Werror -Wno-format-truncation
 
 all: host
 
+build: all
+
 # 1. Regenerate C sources from text masters
 regenerate:
 	python3 scripts/generate_aos_mappings.py --outdir src/generated

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -754,3 +754,12 @@ Next agent must:
 ### Tests
 - `pre-commit run --files Dockerfile demo/docker-compose.yml demo/demo_test.sh README.md Makefile .github/workflows/ci.yml AGENT.md PATCHLOG.md`
 - `make demo-test`
+
+## [2025-06-11 03:00 UTC] verify-all script [codex]
+### Changes
+- Added verify_all.sh script for build, tests and demo smoke tests.
+- Invoked script at end of CI workflow.
+- Documented usage in README.
+### Tests
+- `pre-commit run --files verify_all.sh README.md .github/workflows/ci.yml AGENT.md PATCHLOG.md`
+- `./verify_all.sh`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ Generate `compile_commands.json` for clang-tidy with:
 make compdb
 ```
 
+## One-shot verify
+
+Run the full build, tests and demo smoke tests:
+
+```bash
+./verify_all.sh
+```
+
+
 ## Running AOS in QEMU
 
 **Prerequisite**: install QEMU—e.g., on Debian/Ubuntu:

--- a/verify_all.sh
+++ b/verify_all.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+make build
+make test
+docker-compose -f demo/docker-compose.yml up --build --abort-on-container-exit


### PR DESCRIPTION
## Summary
- add verify_all.sh to run full build, test and demo
- hook verify_all.sh into the CI workflow
- document usage in README
- update Makefile with `build` alias
- record agent and patch logs

## Testing
- `pre-commit run --files verify_all.sh README.md .github/workflows/ci.yml AGENT.md PATCHLOG.md`
- `./verify_all.sh` *(fails: docker daemon missing)*


------
https://chatgpt.com/codex/tasks/task_e_6848f11d656c83259267b67afec244d3