### PR TITLE
Add verify-all make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test install regenerate host bootloader kernel bare run ui ui-check web-ui branch-vm plugins iso efi branch-net desktop-ui ai-service aicell modeld ipc-host branch-dashboard policy net subsystems checklist
+.PHONY: all clean test install regenerate host bootloader kernel bare run ui ui-check web-ui branch-vm plugins iso efi branch-net desktop-ui ai-service aicell modeld ipc-host branch-dashboard policy net subsystems checklist verify-all
 
 MAKEFLAGS += -j$(shell nproc)
 VERSION := 0.3.0
@@ -208,6 +208,7 @@ net-http:
 	@mkdir -p build
 	gcc -Isubsystems/net subsystems/net/net.c examples/http_server.c -o build/http_server
 
+# 4. Verification and tests
 # Aggregate test target used by CI
 test: test-unit test-integration
 	@echo "→ Running full test suite"
@@ -241,9 +242,9 @@ test-negative:
 
 test-all: test-unit test-integration test-merge-ai test-lifecycle test-negative
 
-
-
-
+# Run full verification script
+verify-all:
+	./verify_all.sh
 test-unit:
 	@echo "→ Running unit tests"
 	@mkdir -p build/tests build/plugins

--- a/verify_all.sh
+++ b/verify_all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# Run unit and integration tests
+make test-unit
+make test-integration


### PR DESCRIPTION
## Summary
- introduce verify-all script that runs unit and integration tests
- wire verify-all target into the Makefile
- document verify-all in Makefile comments

## Testing
- `make verify-all`

------
https://chatgpt.com/codex/tasks/task_e_6848f0e6cc148325b832f31a5f0b6482