### PR TITLE
Doc cleanup and verify script fix

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -502,18 +502,24 @@ Next agent must:
 Next agent must:
 - Expand audit coverage across subsystems.
 
-<<<<<< codex/add-verify_all.sh-script-for-ci
+## [2025-06-11 02:59 UTC] layout docs synced [codex]
+- Updated PROJECT_LAYOUT.md to mirror current directory tree.
+- Documented new folders including scripts/ai_providers and demo/
+
+Next agent must:
+- Confirm documentation remains up to date after structural changes.
+
 ## [2025-06-11 03:00 UTC] verify-all script [codex]
 - Added verify_all.sh to run build, tests and demo smoke tests.
 - Hooked script into CI workflow and documented usage.
 
 Next agent must:
 - Expand audit coverage across subsystems.
-=======
-## [2025-06-11 02:59 UTC] layout docs synced [codex]
-- Updated PROJECT_LAYOUT.md to mirror current directory tree.
-- Documented new folders including scripts/ai_providers and demo/.
+
+## [2025-06-11 03:23 UTC] verify script cleanup [codex]
+- Removed leftover merge markers from AGENT.md and verify_all.sh
+- Restored verify_all.sh logic to build, test and run the demo container
 
 Next agent must:
-- Confirm documentation remains up to date after structural changes.
->>>>>> main
+- Investigate missing 'branch' make target causing verify_all.sh failure
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,3 @@ All commits must update `AGENT.md` and `PATCHLOG.md` with a timestamped summary 
 - Run `make test-unit` and `make test-integration` before sending a pull request.
  - Format C sources with `clang-format` and Python with `black`.
 
-### Workflow
-* Fork the repository and create topic branches from `main`.
-* Use descriptive commit messages following the "type: message" style (e.g. `docs: update readme`).
-* Ensure your branch is rebased on the latest `main` before opening a pull request.
-* Link relevant issues and briefly describe testing steps in the PR body.

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -755,7 +755,13 @@ Next agent must:
 - `pre-commit run --files Dockerfile demo/docker-compose.yml demo/demo_test.sh README.md Makefile .github/workflows/ci.yml AGENT.md PATCHLOG.md`
 - `make demo-test`
 
-<<<<<< codex/add-verify_all.sh-script-for-ci
+## [2025-06-11 02:59 UTC] project layout synced [codex]
+### Changes
+- Rewrote PROJECT_LAYOUT.md to match the repository tree.
+- Added descriptions for scripts/ai_providers and demo directories.
+### Tests
+- `pre-commit run --files PROJECT_LAYOUT.md AGENT.md PATCHLOG.md`
+
 ## [2025-06-11 03:00 UTC] verify-all script [codex]
 ### Changes
 - Added verify_all.sh script for build, tests and demo smoke tests.
@@ -764,11 +770,18 @@ Next agent must:
 ### Tests
 - `pre-commit run --files verify_all.sh README.md .github/workflows/ci.yml AGENT.md PATCHLOG.md`
 - `./verify_all.sh`
-=======
-## [2025-06-11 02:59 UTC] project layout synced [codex]
+
+## [2025-06-11 03:30 UTC] v0.3.0 – docs & cleanup [codex]
 ### Changes
-- Rewrote PROJECT_LAYOUT.md to match the repository tree.
-- Added descriptions for scripts/ai_providers and demo directories.
+- Removed stale Beta references and outdated guidelines.
+- Added v0.3.0 preview section and quickstart updates.
 ### Tests
-- `pre-commit run --files PROJECT_LAYOUT.md AGENT.md PATCHLOG.md`
->>>>>> main
+- `pre-commit run --files README.md CONTRIBUTING.md PATCHLOG.md`
+
+
+## [2025-06-11 03:23 UTC] verify script cleanup [codex]
+### Changes
+- Removed merge conflict markers from verify_all.sh and AGENT.md
+- Restored verify_all.sh to run build, tests and demo container
+### Tests
+- `pre-commit run --files verify_all.sh AGENT.md`

--- a/README.md
+++ b/README.md
@@ -10,27 +10,23 @@ Minimal experimental OS used for interpreter tests. The latest release adds a
 task orchestrator with plugin-based AI providers, coverage tracking and live UI
 previews.
 
+## v0.3.0 Preview
+
+Milestone&nbsp;1 introduces:
+- persistent branches with federation support
+- plugin hot-swap with basic sandboxing
+- AI provider integration and web branch UI
+- a `verify_all.sh` script for one-shot build and tests
+
 ## Quickstart
 
 ```bash
 git clone https://github.com/RedactedCoder23/AOS.git
 cd AOS
-make bootloader kernel host
-./build/host_test
-```
+./verify_all.sh
 
-Launch the branch UI and React front-end:
-
-```bash
-python3 scripts/branch_ui.py &
-cd ui && npm install && npm start
-```
-
-Start the credential vault and inspect the audit log:
-
-```bash
-python3 scripts/ai_cred_manager.py daemon &
-python3 scripts/aos_audit.py show --file /var/log/aos-audit.log
+# Or run the demo container
+docker-compose -f demo/docker-compose.yml up --build
 ```
 
 ## Setup
@@ -93,15 +89,6 @@ Generate `compile_commands.json` for clang-tidy with:
 ```bash
 make compdb
 ```
-
-## One-shot verify
-
-Run the full build, tests and demo smoke tests:
-
-```bash
-./verify_all.sh
-```
-
 
 ## Running AOS in QEMU
 
@@ -332,14 +319,3 @@ See [AGENT.md](AGENT.md) and [PATCHLOG.md](PATCHLOG.md) for development logs. Th
 AOS is released under the [MIT License](LICENSE). This permits reuse, modification and distribution
 as long as the license notice is included. The project is provided **as is** without warranty.
 
-## Demo Quickstart
-
-```bash
-git clone https://…/AOS-main.git
-cd AOS-main
-docker-compose up --build
-```
-
-Visit http://localhost:8080 for the UI.
-
-The Flask API runs on http://localhost:5000.

--- a/verify_all.sh
+++ b/verify_all.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 set -e
-<<<<<< codex/add-verify-all-target-to-makefile
 
-# Run unit and integration tests
-make test-unit
-make test-integration
-=======
+# Build all components and run tests
 make build
 make test
+
 docker-compose -f demo/docker-compose.yml up --build --abort-on-container-exit
->>>>>> main
+


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in AGENT log and cleanup entry order
- restore verify_all.sh functionality for build and tests
- document the cleanup in PATCHLOG

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md PATCHLOG.md AGENT.md verify_all.sh ARCHITECTURE.md PROJECT_LAYOUT.md`
- `./verify_all.sh` *(fails: No rule to make target 'branch', needed by 'subsystems')*

------
https://chatgpt.com/codex/tasks/task_e_6848f3cc58348325ad5b8444bdcd35f8