### PR TITLE
Implement dynamic AI provider loader

### DIFF
--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -1,13 +1,25 @@
 # AI Provider Plugins
 
 Providers implement `AIProvider.generate(prompt) -> str` and are loaded from
-`providers.json`. Example configuration:
+`providers.json`.
+
+## Plugin loader
+
+The file maps a provider alias to a fully qualified class path. Example
+`providers.json`:
 
 ```json
 {
-  "openai": {"module": "openai_provider", "class": "OpenAIProvider"},
-  "echo": {"module": "mock_provider", "class": "MockProvider"}
+  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider",
+  "echo": "scripts.ai_providers.echo_provider.EchoProvider"
 }
 ```
 
-Plugins can be hot-swapped at runtime in tests by reloading the provider loader.
+Call `get_provider(alias)` to retrieve an instance:
+
+```python
+from scripts.ai_providers.loader import get_provider
+provider = get_provider("openai")
+```
+
+Plugins can be hot-swapped at runtime in tests by reloading the loader module.

--- a/providers.json
+++ b/providers.json
@@ -1,4 +1,5 @@
 {
-  "openai": {"module": "openai_provider", "class": "OpenAIProvider"},
-  "local-llama": {"module": "mock_provider", "class": "MockProvider"}
+  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider",
+  "local-llama": "scripts.ai_providers.mock_provider.MockProvider",
+  "echo": "scripts.ai_providers.echo_provider.EchoProvider"
 }

--- a/scripts/ai_providers/echo_provider.py
+++ b/scripts/ai_providers/echo_provider.py
@@ -1,0 +1,8 @@
+from .base import AIProvider
+
+
+class EchoProvider(AIProvider):
+    """Provider that simply echoes the prompt."""
+
+    def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
+        return prompt

--- a/scripts/ai_providers/loader.py
+++ b/scripts/ai_providers/loader.py
@@ -1,0 +1,20 @@
+import json
+import os
+import importlib
+from .base import AIProvider
+
+
+def get_provider(alias: str) -> AIProvider:
+    """Return provider instance for *alias* using providers.json mapping."""
+    cfg = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "providers.json"
+    )
+    with open(cfg, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    path = data.get(alias)
+    if not path:
+        raise ValueError(f"Unknown provider: {alias}")
+    module_path, class_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    return cls(alias)

--- a/tests/python/test_ai_provider_loader.py
+++ b/tests/python/test_ai_provider_loader.py
@@ -1,0 +1,18 @@
+import unittest
+
+from scripts.ai_providers.loader import get_provider
+from scripts.ai_providers.echo_provider import EchoProvider
+
+
+class LoaderTest(unittest.TestCase):
+    def test_load_echo(self):
+        prov = get_provider("echo")
+        self.assertIsInstance(prov, EchoProvider)
+
+    def test_unknown(self):
+        with self.assertRaises(ValueError):
+            get_provider("nonexistent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_ai_provider_plugins.py
+++ b/tests/python/test_ai_provider_plugins.py
@@ -1,25 +1,18 @@
 import os
 import sys
-import importlib
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from scripts import ai_backend, agent_orchestrator  # noqa: E402
+from scripts.ai_providers.loader import get_provider  # noqa: E402
 
 
 class ProviderPluginTest(unittest.TestCase):
     def test_discovery_and_generate(self):
-        # reload modules to pick up providers.json
-        importlib.reload(ai_backend)
-        importlib.reload(agent_orchestrator)
-        ai_backend._load_providers()
-        agent_orchestrator._load_providers()
-        provs = ai_backend.PROVIDERS
-        self.assertIn("openai", provs)
-        self.assertIn("local-llama", provs)
-        self.assertEqual(provs["openai"].generate("hi"), "hi")
-        self.assertEqual(provs["local-llama"].generate("hi"), "mock-response")
+        openai = get_provider("openai")
+        llama = get_provider("local-llama")
+        self.assertEqual(openai.generate("hi"), "hi")
+        self.assertEqual(llama.generate("hi"), "mock-response")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add loader that imports provider classes dynamically
- update provider mapping format and include an EchoProvider
- refactor merge_ai, ai_backend and orchestrator to use loader
- document provider loader usage
- test provider loader and update plugin tests

## Testing
- `pytest tests/python/test_ai_provider_loader.py tests/python/test_ai_provider_plugins.py tests/python/test_ai_backend.py::AiBackendTest::test_offline -q`

------
https://chatgpt.com/codex/tasks/task_e_6849030e59808325a1724965680941fb