### PR TITLE
Add provider override flag

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -523,3 +523,11 @@ Next agent must:
 Next agent must:
 - Investigate missing 'branch' make target causing verify_all.sh failure
 
+## [2025-06-11 03:45 UTC] cli provider override [codex]
+- Added `--provider` flag to agent_runner and passed meta via `AOS_TASK_META`.
+- merge_ai now reads the provider override from task metadata.
+- Documented new CLI option in README.
+
+Next agent must:
+- Investigate missing 'branch' make target causing verify_all.sh failure
+

--- a/PATCHLOG.md
+++ b/PATCHLOG.md
@@ -785,3 +785,14 @@ Next agent must:
 - Restored verify_all.sh to run build, tests and demo container
 ### Tests
 - `pre-commit run --files verify_all.sh AGENT.md`
+
+## [2025-06-11 03:45 UTC] cli provider override [codex]
+### Changes
+- Added `--provider` flag to agent_runner.py.
+- merge_ai reads provider from `AOS_TASK_META` when present.
+- Documented CLI option in README and added unit tests.
+### Tests
+- `pre-commit run --files scripts/agent_runner.py scripts/merge_ai.py tests/python/test_agent_runner_cli.py README.md AGENT.md PATCHLOG.md`
+- `make test-unit`
+- `make test-integration`
+- `pytest -q tests/python/test_agent_runner_cli.py`

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ Generate `compile_commands.json` for clang-tidy with:
 make compdb
 ```
 
+## CLI Options
+
+The helper `agent_runner.py` accepts a `--provider` flag to override the AI
+provider used by `merge_ai.py`.
+
+### Usage
+
+```bash
+python3 scripts/agent_runner.py --provider echo "<cmd>" hb.json result.json
+```
+
 ## Running AOS in QEMU
 
 **Prerequisite**: install QEMU—e.g., on Debian/Ubuntu:

--- a/scripts/agent_runner.py
+++ b/scripts/agent_runner.py
@@ -1,26 +1,35 @@
+import argparse
 import json
 import sys
 import time
 import threading
 import subprocess
 import shlex
+import os
 
 HEARTBEAT_INTERVAL = 1
 
 
-def main() -> int:
-    if len(sys.argv) < 4:
-        print("usage: agent_runner.py <cmd> <hb_file> <result_file>")
-        return 1
-    cmd = sys.argv[1]
-    hb = sys.argv[2]
-    result = sys.argv[3]
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="run a command with heartbeat")
+    parser.add_argument("cmd", help="command to execute")
+    parser.add_argument("hb_file", help="heartbeat file")
+    parser.add_argument("result_file", help="result json file")
+    parser.add_argument("--provider", help="AI provider override")
+    args = parser.parse_args(argv)
+
+    cmd = args.cmd
+    hb = args.hb_file
+    result = args.result_file
     if cmd.startswith("["):
-        args = json.loads(cmd)
+        proc_args = json.loads(cmd)
     else:
-        args = shlex.split(cmd)
+        proc_args = shlex.split(cmd)
+    env = os.environ.copy()
+    if args.provider:
+        env["AOS_TASK_META"] = json.dumps({"provider": args.provider})
     proc = subprocess.Popen(
-        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        proc_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env
     )
 
     def heartbeat() -> None:

--- a/scripts/merge_ai.py
+++ b/scripts/merge_ai.py
@@ -77,6 +77,13 @@ def call_llm(prompt: str, provider_name: str | None = None) -> str:
     if os.environ.get("AOS_AI_OFFLINE"):
         return ""
     _load_providers()
+    if provider_name is None:
+        meta = os.environ.get("AOS_TASK_META")
+        if meta:
+            try:
+                provider_name = json.loads(meta).get("provider")
+            except Exception:
+                provider_name = None
     provider_name = provider_name or os.environ.get("AOS_AI_PROVIDER", "openai")
     prov = PROVIDERS.get(provider_name)
     if prov is None:

--- a/tests/python/test_agent_runner_cli.py
+++ b/tests/python/test_agent_runner_cli.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import json
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from scripts import agent_runner  # noqa: E402
+
+
+class AgentRunnerCliTest(unittest.TestCase):
+    def _run(self, args):
+        with tempfile.TemporaryDirectory() as tmp:
+            hb = os.path.join(tmp, "hb")
+            res = os.path.join(tmp, "res.json")
+            cmd = (
+                f"{sys.executable} -c "
+                "\"import os, json; meta=os.getenv('AOS_TASK_META'); "
+                "print(json.loads(meta)['provider'] if meta else "
+                "os.getenv('AOS_AI_PROVIDER','openai'))\""
+            )
+            argv = ["agent_runner.py", cmd, hb, res] + args
+            with mock.patch.object(sys, "argv", argv):
+                agent_runner.main()
+            with open(res, "r") as fh:
+                data = json.load(fh)
+            return data["stdout"].strip()
+
+    def test_provider_flag(self):
+        out = self._run(["--provider", "echo"])
+        self.assertEqual(out, "echo")
+
+    def test_default_provider(self):
+        if "AOS_AI_PROVIDER" in os.environ:
+            del os.environ["AOS_AI_PROVIDER"]
+        out = self._run([])
+        self.assertEqual(out, "openai")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--provider` flag to agent_runner and forward via `AOS_TASK_META`
- read provider override in merge_ai
- show provider flag in README docs
- test CLI provider behaviour
- update logs

## Testing
- `pre-commit run --files scripts/agent_runner.py scripts/merge_ai.py tests/python/test_agent_runner_cli.py README.md AGENT.md PATCHLOG.md`
- `make test-unit` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `make test-integration`
- `pytest -q tests/python/test_agent_runner_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6849032838808325a4813282e0758cf4