### PR TITLE
Add hot reload to AI provider loader

### DIFF
--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -11,3 +11,7 @@ Providers implement `AIProvider.generate(prompt) -> str` and are loaded from
 ```
 
 Plugins can be hot-swapped at runtime in tests by reloading the provider loader.
+The loader monitors ``providers.json`` and re-reads it whenever the file
+modification time changes.  New providers become available to running
+processes automatically on the next call to ``get_provider()``.  Errors while
+loading are ignored so malformed entries do not interrupt execution.

--- a/scripts/agent_orchestrator.py
+++ b/scripts/agent_orchestrator.py
@@ -11,6 +11,7 @@ from typing import Iterable, Dict, List
 import importlib
 
 from src.api import events
+from .ai_providers import loader
 from .ai_providers.base import AIProvider
 from src.branch.task_definitions import Task
 
@@ -26,7 +27,7 @@ class LoadStats:
 MAX_AGENTS = int(os.environ.get("MAX_AGENTS", "4"))
 TASKS_PER_AGENT = int(os.environ.get("TASKS_PER_AGENT", "3"))
 METRICS: Dict[int, Dict[str, float]] = {}
-PROVIDERS: Dict[str, AIProvider] = {}
+PROVIDERS: Dict[str, AIProvider] = loader.PROVIDERS
 
 try:
     import yaml  # type: ignore
@@ -89,21 +90,8 @@ def calc_desired_agents(stats: LoadStats) -> int:
 
 
 def _load_providers() -> None:
-    if PROVIDERS:
-        return
-    cfg = os.path.join(os.path.dirname(os.path.dirname(__file__)), "providers.json")
-    try:
-        with open(cfg, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except Exception:  # pragma: no cover - missing config
-        data = {}
-    for name, info in data.items():
-        try:
-            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
-            cls = getattr(mod, info["class"])
-            PROVIDERS[name] = cls(name)
-        except Exception:  # pragma: no cover - plugin errors
-            continue
+    """Compatibility wrapper around :func:`loader.load_providers`."""
+    loader.load_providers()
 
 
 def _load_spec(branch_id: int) -> List[Task]:
@@ -157,7 +145,7 @@ def _run_agent(
         attempts += 1
         try:
             if provider:
-                prov = PROVIDERS.get(provider)
+                prov = loader.get_provider(provider)
                 if prov is None:
                     raise RuntimeError(f"provider {provider} not found")
                 out = prov.generate(task.command)

--- a/scripts/ai_backend.py
+++ b/scripts/ai_backend.py
@@ -1,38 +1,20 @@
 #!/usr/bin/env python3
 """Backend helper to query AI provider plugins."""
-import importlib
-import json
 import os
 import sys
+from scripts.ai_providers import loader
 from scripts.ai_providers.base import AIProvider
 
-PROVIDERS: dict[str, AIProvider] = {}
+PROVIDERS: dict[str, AIProvider] = loader.PROVIDERS
 
 
 def _load_providers() -> None:
-    """Load provider plugins from ``providers.json``."""
-    if PROVIDERS:
-        return
-    cfg_path = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), "providers.json"
-    )
-    try:
-        with open(cfg_path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except Exception:  # pragma: no cover - config missing
-        data = {}
-    for name, info in data.items():
-        try:
-            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
-            cls = getattr(mod, info["class"])
-            PROVIDERS[name] = cls(name)
-        except Exception:  # pragma: no cover - plugin errors
-            continue
+    """Compatibility wrapper around :func:`loader.load_providers`."""
+    loader.load_providers()
 
 
 def _get_provider(name: str):
-    _load_providers()
-    return PROVIDERS.get(name)
+    return loader.get_provider(name)
 
 
 PROMPT_ERR = "usage: ai_backend.py <prompt>"

--- a/scripts/ai_providers/loader.py
+++ b/scripts/ai_providers/loader.py
@@ -1,0 +1,52 @@
+import importlib
+import json
+import os
+from typing import Dict
+
+from .base import AIProvider
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+_CFG = os.path.join(_ROOT, "providers.json")
+
+PROVIDERS: Dict[str, AIProvider] = {}
+_mtime: float | None = None
+
+
+def _load_providers() -> None:
+    """Load provider plugins from :data:`providers.json`."""
+    global _mtime
+    try:
+        mtime = os.path.getmtime(_CFG)
+    except OSError:
+        mtime = None
+    if PROVIDERS and mtime == _mtime:
+        return
+
+    data = {}
+    if mtime is not None:
+        try:
+            with open(_CFG, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = {}
+
+    PROVIDERS.clear()
+    for name, info in data.items():
+        try:
+            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
+            cls = getattr(mod, info["class"])
+            PROVIDERS[name] = cls(name)
+        except Exception:
+            continue
+    _mtime = mtime
+
+
+def load_providers() -> None:
+    """Public wrapper to (re)load provider map if needed."""
+    _load_providers()
+
+
+def get_provider(name: str) -> AIProvider | None:
+    """Return provider instance by ``name`` reloading config if changed."""
+    _load_providers()
+    return PROVIDERS.get(name)

--- a/scripts/merge_ai.py
+++ b/scripts/merge_ai.py
@@ -13,27 +13,15 @@ import logging
 from typing import List
 import importlib
 
+from scripts.ai_providers import loader
 from scripts.ai_providers.base import AIProvider
 
-PROVIDERS: dict[str, AIProvider] = {}
+PROVIDERS: dict[str, AIProvider] = loader.PROVIDERS
 
 
 def _load_providers() -> None:
-    if PROVIDERS:
-        return
-    cfg = os.path.join(os.path.dirname(os.path.dirname(__file__)), "providers.json")
-    try:
-        with open(cfg, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except Exception:
-        data = {}
-    for name, info in data.items():
-        try:
-            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
-            cls = getattr(mod, info["class"])
-            PROVIDERS[name] = cls(name)
-        except Exception:
-            continue
+    """Compatibility wrapper around :func:`loader.load_providers`."""
+    loader.load_providers()
 
 
 MAX_HUNK_SIZE = 4096

--- a/tests/python/test_provider_hotreload.py
+++ b/tests/python/test_provider_hotreload.py
@@ -1,0 +1,30 @@
+import json
+import time
+import unittest
+
+from scripts.ai_providers import loader
+
+
+class ProviderHotReloadTest(unittest.TestCase):
+    def test_reload_on_change(self):
+        orig = json.load(open(loader._CFG, "r", encoding="utf-8"))
+        try:
+            loader.load_providers()
+            self.assertIsNone(loader.get_provider("alias2"))
+            data = orig.copy()
+            data["alias2"] = {"module": "mock_provider", "class": "MockProvider"}
+            with open(loader._CFG, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            time.sleep(1)
+            prov = loader.get_provider("alias2")
+            self.assertIsNotNone(prov)
+            self.assertEqual(prov.generate("hi"), "mock-response")
+        finally:
+            with open(loader._CFG, "w", encoding="utf-8") as fh:
+                json.dump(orig, fh)
+            loader.PROVIDERS.clear()
+            loader.load_providers()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `scripts/ai_providers/loader.py` with mtime-based reload
- refactor orchestrator, backend and merge_ai to use new loader
- document provider hot-reload behaviour
- add regression test verifying providers.json updates

## Testing
- `pytest tests/python/test_provider_hotreload.py -q`
- `pytest -q` *(fails: long runtime / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684903316d1483258382cccf9802bef1