### PR TITLE
Add default echo and OpenAI AI providers

### DIFF
--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -5,9 +5,11 @@ Providers implement `AIProvider.generate(prompt) -> str` and are loaded from
 
 ```json
 {
-  "openai": {"module": "openai_provider", "class": "OpenAIProvider"},
-  "echo": {"module": "mock_provider", "class": "MockProvider"}
+  "echo": "scripts.ai_providers.echo_provider.EchoProvider",
+  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider"
 }
 ```
 
-Plugins can be hot-swapped at runtime in tests by reloading the provider loader.
+`echo` simply returns its prompt. The `openai` plugin forwards prompts to the
+OpenAI ChatCompletion API. Plugins can be hot-swapped at runtime in tests by
+reloading the provider loader.

--- a/providers.json
+++ b/providers.json
@@ -1,4 +1,4 @@
 {
-  "openai": {"module": "openai_provider", "class": "OpenAIProvider"},
-  "local-llama": {"module": "mock_provider", "class": "MockProvider"}
+  "echo": "scripts.ai_providers.echo_provider.EchoProvider",
+  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider"
 }

--- a/scripts/agent_orchestrator.py
+++ b/scripts/agent_orchestrator.py
@@ -99,8 +99,13 @@ def _load_providers() -> None:
         data = {}
     for name, info in data.items():
         try:
-            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
-            cls = getattr(mod, info["class"])
+            if isinstance(info, str):
+                module_path, cls_name = info.rsplit(".", 1)
+            else:  # backward compat
+                module_path = f"scripts.ai_providers.{info['module']}"
+                cls_name = info["class"]
+            mod = importlib.import_module(module_path)
+            cls = getattr(mod, cls_name)
             PROVIDERS[name] = cls(name)
         except Exception:  # pragma: no cover - plugin errors
             continue

--- a/scripts/ai_backend.py
+++ b/scripts/ai_backend.py
@@ -23,8 +23,13 @@ def _load_providers() -> None:
         data = {}
     for name, info in data.items():
         try:
-            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
-            cls = getattr(mod, info["class"])
+            if isinstance(info, str):
+                module_path, cls_name = info.rsplit(".", 1)
+            else:  # backward compat
+                module_path = f"scripts.ai_providers.{info['module']}"
+                cls_name = info["class"]
+            mod = importlib.import_module(module_path)
+            cls = getattr(mod, cls_name)
             PROVIDERS[name] = cls(name)
         except Exception:  # pragma: no cover - plugin errors
             continue
@@ -33,6 +38,11 @@ def _load_providers() -> None:
 def _get_provider(name: str):
     _load_providers()
     return PROVIDERS.get(name)
+
+
+def get_provider(name: str):
+    """Public helper returning provider instance by *name*."""
+    return _get_provider(name)
 
 
 PROMPT_ERR = "usage: ai_backend.py <prompt>"

--- a/scripts/ai_providers/base.py
+++ b/scripts/ai_providers/base.py
@@ -1,8 +1,17 @@
-class AIProvider:
-    """Base AI provider interface."""
+from __future__ import annotations
+
+"""Base classes for AI provider plugins."""
+
+from abc import ABC, abstractmethod
+
+
+class AIProvider(ABC):
+    """Abstract provider interface."""
 
     def __init__(self, name: str):
         self.name = name
 
-    def generate(self, prompt: str) -> str:  # pragma: no cover - to be implemented
+    @abstractmethod
+    def generate(self, prompt: str) -> str:
+        """Return text generated for ``prompt``."""
         raise NotImplementedError

--- a/scripts/ai_providers/echo_provider.py
+++ b/scripts/ai_providers/echo_provider.py
@@ -1,0 +1,8 @@
+from scripts.ai_providers.base import AIProvider
+
+
+class EchoProvider(AIProvider):
+    """Simple provider that echoes the prompt."""
+
+    def generate(self, prompt: str) -> str:
+        return prompt

--- a/scripts/ai_providers/openai_provider.py
+++ b/scripts/ai_providers/openai_provider.py
@@ -1,8 +1,13 @@
-from .base import AIProvider
+from scripts.ai_providers.base import AIProvider
+import openai
 
 
 class OpenAIProvider(AIProvider):
-    """Dummy OpenAI provider that echoes the prompt."""
+    """Real OpenAI provider using the ChatCompletion API."""
 
     def generate(self, prompt: str) -> str:
-        return prompt
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message["content"]

--- a/scripts/merge_ai.py
+++ b/scripts/merge_ai.py
@@ -29,8 +29,13 @@ def _load_providers() -> None:
         data = {}
     for name, info in data.items():
         try:
-            mod = importlib.import_module(f"scripts.ai_providers.{info['module']}")
-            cls = getattr(mod, info["class"])
+            if isinstance(info, str):
+                module_path, cls_name = info.rsplit(".", 1)
+            else:
+                module_path = f"scripts.ai_providers.{info['module']}"
+                cls_name = info["class"]
+            mod = importlib.import_module(module_path)
+            cls = getattr(mod, cls_name)
             PROVIDERS[name] = cls(name)
         except Exception:
             continue

--- a/tests/python/test_ai_backend.py
+++ b/tests/python/test_ai_backend.py
@@ -24,8 +24,12 @@ class AiBackendTest(unittest.TestCase):
 
     def test_success(self):
         mod = importlib.reload(ai_backend)
+        os.environ["AOS_AI_PROVIDER"] = "echo"
         sys.argv = ["ai_backend.py", "hello"]
-        self.assertEqual(mod.main(), 0)
+        try:
+            self.assertEqual(mod.main(), 0)
+        finally:
+            del os.environ["AOS_AI_PROVIDER"]
 
     def test_no_args(self):
         mod = importlib.reload(ai_backend)

--- a/tests/python/test_ai_provider_plugins.py
+++ b/tests/python/test_ai_provider_plugins.py
@@ -3,23 +3,20 @@ import sys
 import importlib
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.")))
 
-from scripts import ai_backend, agent_orchestrator  # noqa: E402
+from scripts import ai_backend  # noqa: E402
+from scripts.ai_providers.openai_provider import OpenAIProvider  # noqa: E402
 
 
 class ProviderPluginTest(unittest.TestCase):
-    def test_discovery_and_generate(self):
-        # reload modules to pick up providers.json
+    def test_get_provider(self):
+        # reload to pick up providers.json
         importlib.reload(ai_backend)
-        importlib.reload(agent_orchestrator)
-        ai_backend._load_providers()
-        agent_orchestrator._load_providers()
-        provs = ai_backend.PROVIDERS
-        self.assertIn("openai", provs)
-        self.assertIn("local-llama", provs)
-        self.assertEqual(provs["openai"].generate("hi"), "hi")
-        self.assertEqual(provs["local-llama"].generate("hi"), "mock-response")
+        prov = ai_backend.get_provider("echo")
+        assert prov is not None
+        self.assertEqual(prov.generate("hi"), "hi")
+        self.assertIsInstance(ai_backend.get_provider("openai"), OpenAIProvider)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `EchoProvider` and real OpenAI provider
- support simplified provider paths in loader logic
- document example provider configuration
- adjust tests for new plugins

## Testing
- `pytest -q tests/python/test_ai_backend.py tests/python/test_ai_provider_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_68490596e8388325b258a1af6d31164f