### PR TITLE
Resolve plugin loader conflicts and cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ for downloadable archives and changelogs.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
 Additional developer documentation is available under the [docs/](docs/) directory.
+See [docs/REMAINING.md](docs/REMAINING.md) for tasks pending implementation.
 See [docs/profiler_usage.md](docs/profiler_usage.md) for the profiler stub.
 See [AGENT.md](AGENT.md) and [PATCHLOG.md](PATCHLOG.md) for development logs. The roadmap is maintained in [ROADMAP.md](ROADMAP.md).
 

--- a/docs/REMAINING.md
+++ b/docs/REMAINING.md
@@ -1,0 +1,10 @@
+# Remaining Work
+
+The following areas are not yet fully implemented and require future attention:
+
+- Expand audit log coverage across all subsystems.
+- Investigate the missing `branch` Makefile target referenced by `verify_all.sh`.
+- Improve documentation for newly added subsystems and update diagrams regularly.
+
+These tasks are tracked in `AGENT.md` and should be addressed in subsequent versions.
+

--- a/docs/ai_providers.md
+++ b/docs/ai_providers.md
@@ -1,60 +1,25 @@
 # AI Provider Plugins
 
-<<<<<< codex/implement-dynamic-ai-provider-loader
-Providers implement `AIProvider.generate(prompt) -> str` and are loaded from
-`providers.json`.
+`AIProvider` implementations supply text generation services for the orchestrator. Providers are discovered from `providers.json` at the repository root.
 
-## Plugin loader
-
-The file maps a provider alias to a fully qualified class path. Example
-`providers.json`:
+Example `providers.json`:
 
 ```json
 {
-  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider",
+  "openai": {"module": "openai_provider", "class": "OpenAIProvider"},
+  "local-llama": {"module": "mock_provider", "class": "MockProvider"},
   "echo": "scripts.ai_providers.echo_provider.EchoProvider"
 }
 ```
 
-Call `get_provider(alias)` to retrieve an instance:
+Use `get_provider(alias)` to retrieve an instance:
 
 ```python
 from scripts.ai_providers.loader import get_provider
 provider = get_provider("openai")
 ```
 
-Plugins can be hot-swapped at runtime in tests by reloading the loader module.
-=======
-`AIProvider` implementations supply text generation services for the
-orchestrator.  Available providers are discovered from `providers.json` at the
-repository root:
-
-```json
-{
-<<<<<< codex/add-echo-and-openai-provider-plugins
-  "echo": "scripts.ai_providers.echo_provider.EchoProvider",
-  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider"
-}
-```
-
-`echo` simply returns its prompt. The `openai` plugin forwards prompts to the
-OpenAI ChatCompletion API. Plugins can be hot-swapped at runtime in tests by
-reloading the provider loader.
-=======
-  "openai": {"module": "openai_provider", "class": "OpenAIProvider"},
-  "local-llama": {"module": "mock_provider", "class": "MockProvider"}
-}
-```
-
-<<<<<< codex/implement-plugin-loader-hot-reload
-Plugins can be hot-swapped at runtime in tests by reloading the provider loader.
-The loader monitors ``providers.json`` and re-reads it whenever the file
-modification time changes.  New providers become available to running
-processes automatically on the next call to ``get_provider()``.  Errors while
-loading are ignored so malformed entries do not interrupt execution.
-=======
-`scripts.ai_backend` and other helpers load this file on demand.  Plugins can be
-hot-swapped in tests by reloading the loader module.
+The loader monitors the configuration file and reloads plugins when it changes so tests can hot-swap providers.
 
 ## Creating a custom AIProvider
 
@@ -65,8 +30,6 @@ hot-swapped in tests by reloading the loader module.
    from .base import AIProvider
 
    class MyProvider(AIProvider):
-       """Return a canned reply for demonstration."""
-
        def generate(self, prompt: str) -> str:
            return "hello from my provider"
    ```
@@ -82,17 +45,13 @@ hot-swapped in tests by reloading the loader module.
 3. Retrieve the provider from the loader:
 
    ```python
-   from scripts.ai_backend import _get_provider as get_provider
-
+   from scripts.ai_providers.loader import get_provider
    prov = get_provider("my-provider")
    ```
 
-   The active provider used by command line tools can also be overridden via the
-   `AOS_AI_PROVIDER` environment variable:
+The active provider used by command line tools can also be overridden via the `AOS_AI_PROVIDER` environment variable:
 
-   ```bash
-   AOS_AI_PROVIDER=my-provider ./scripts/ai_backend.py "Hello"
-   ```
+```bash
+AOS_AI_PROVIDER=my-provider ./scripts/ai_backend.py "Hello"
+```
 
-See `scripts.ai_backend._get_provider()` for the loader implementation.
->>>>>> main

--- a/providers.json
+++ b/providers.json
@@ -1,10 +1,5 @@
 {
-<<<<<< codex/add-echo-and-openai-provider-plugins
-  "echo": "scripts.ai_providers.echo_provider.EchoProvider",
-  "openai": "scripts.ai_providers.openai_provider.OpenAIProvider"
-=======
   "openai": "scripts.ai_providers.openai_provider.OpenAIProvider",
   "local-llama": "scripts.ai_providers.mock_provider.MockProvider",
   "echo": "scripts.ai_providers.echo_provider.EchoProvider"
->>>>>> main
 }

--- a/scripts/ai_backend.py
+++ b/scripts/ai_backend.py
@@ -2,7 +2,7 @@
 """Backend helper to query AI provider plugins."""
 import os
 import sys
-<<<<<< codex/implement-plugin-loader-hot-reload
+
 from scripts.ai_providers import loader
 from scripts.ai_providers.base import AIProvider
 
@@ -10,44 +10,15 @@ PROVIDERS: dict[str, AIProvider] = loader.PROVIDERS
 
 
 def _load_providers() -> None:
-<<<<<< codex/add-echo-and-openai-provider-plugins
-    """Load provider plugins from ``providers.json``."""
-    if PROVIDERS:
-        return
-    cfg_path = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), "providers.json"
-    )
-    try:
-        with open(cfg_path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except Exception:  # pragma: no cover - config missing
-        data = {}
-    for name, info in data.items():
-        try:
-            if isinstance(info, str):
-                module_path, cls_name = info.rsplit(".", 1)
-            else:  # backward compat
-                module_path = f"scripts.ai_providers.{info['module']}"
-                cls_name = info["class"]
-            mod = importlib.import_module(module_path)
-            cls = getattr(mod, cls_name)
-            PROVIDERS[name] = cls(name)
-        except Exception:  # pragma: no cover - plugin errors
-            continue
-=======
     """Compatibility wrapper around :func:`loader.load_providers`."""
     loader.load_providers()
->>>>>> main
 
 
-def _get_provider(name: str):
+def _get_provider(name: str) -> AIProvider:
     return loader.get_provider(name)
-=======
-from scripts.ai_providers.loader import get_provider
->>>>> main
 
 
-def get_provider(name: str):
+def get_provider(name: str) -> AIProvider:
     """Public helper returning provider instance by *name*."""
     return _get_provider(name)
 
@@ -55,7 +26,7 @@ def get_provider(name: str):
 PROMPT_ERR = "usage: ai_backend.py <prompt>"
 
 
-def main():
+def main() -> int:
     if len(sys.argv) < 2:
         print(PROMPT_ERR, file=sys.stderr)
         return 1

--- a/scripts/ai_providers/echo_provider.py
+++ b/scripts/ai_providers/echo_provider.py
@@ -1,18 +1,8 @@
-<<<<<< codex/add-echo-and-openai-provider-plugins
-from scripts.ai_providers.base import AIProvider
-
-
-class EchoProvider(AIProvider):
-    """Simple provider that echoes the prompt."""
-
-    def generate(self, prompt: str) -> str:
-=======
 from .base import AIProvider
 
 
 class EchoProvider(AIProvider):
     """Provider that simply echoes the prompt."""
 
-    def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
->>>>>> main
+    def generate(self, prompt: str) -> str:
         return prompt

--- a/scripts/merge_ai.py
+++ b/scripts/merge_ai.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """LLM-assisted three-way merge helper."""
-
 from __future__ import annotations
 
 import argparse
@@ -11,8 +10,6 @@ import sys
 import time
 import logging
 from typing import List
-<<<<<< codex/implement-plugin-loader-hot-reload
-import importlib
 
 from scripts.ai_providers import loader
 from scripts.ai_providers.base import AIProvider
@@ -21,37 +18,8 @@ PROVIDERS: dict[str, AIProvider] = loader.PROVIDERS
 
 
 def _load_providers() -> None:
-<<<<<< codex/add-echo-and-openai-provider-plugins
-    if PROVIDERS:
-        return
-    cfg = os.path.join(os.path.dirname(os.path.dirname(__file__)), "providers.json")
-    try:
-        with open(cfg, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except Exception:
-        data = {}
-    for name, info in data.items():
-        try:
-            if isinstance(info, str):
-                module_path, cls_name = info.rsplit(".", 1)
-            else:
-                module_path = f"scripts.ai_providers.{info['module']}"
-                cls_name = info["class"]
-            mod = importlib.import_module(module_path)
-            cls = getattr(mod, cls_name)
-            PROVIDERS[name] = cls(name)
-        except Exception:
-            continue
-=======
     """Compatibility wrapper around :func:`loader.load_providers`."""
     loader.load_providers()
-=======
-from scripts.ai_providers.loader import get_provider
->>>>>> main
->>>>>> main
-
-
-MAX_HUNK_SIZE = 4096
 
 
 def run_diff(base: str, main: str, branch: str) -> str:
@@ -87,12 +55,13 @@ def split_hunks(patch: str) -> List[str]:
     return hunks
 
 
+MAX_HUNK_SIZE = 4096
+
+
 def call_llm(prompt: str, provider_name: str | None = None) -> str:
     """Send *prompt* to an AI provider and return the response."""
     if os.environ.get("AOS_AI_OFFLINE"):
         return ""
-<<<<<< codex/implement-dynamic-ai-provider-loader
-=======
     _load_providers()
     if provider_name is None:
         meta = os.environ.get("AOS_TASK_META")
@@ -101,9 +70,8 @@ def call_llm(prompt: str, provider_name: str | None = None) -> str:
                 provider_name = json.loads(meta).get("provider")
             except Exception:
                 provider_name = None
->>>>>> main
     provider_name = provider_name or os.environ.get("AOS_AI_PROVIDER", "openai")
-    provider = get_provider(provider_name)
+    provider = loader.get_provider(provider_name)
     return provider.generate(prompt)
 
 

--- a/tests/python/test_ai_provider_plugins.py
+++ b/tests/python/test_ai_provider_plugins.py
@@ -1,33 +1,21 @@
 import os
 import sys
+import importlib
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-<<<<<< codex/add-echo-and-openai-provider-plugins
 from scripts import ai_backend  # noqa: E402
 from scripts.ai_providers.openai_provider import OpenAIProvider  # noqa: E402
 
 
 class ProviderPluginTest(unittest.TestCase):
     def test_get_provider(self):
-        # reload to pick up providers.json
         importlib.reload(ai_backend)
         prov = ai_backend.get_provider("echo")
-        assert prov is not None
+        self.assertIsNotNone(prov)
         self.assertEqual(prov.generate("hi"), "hi")
         self.assertIsInstance(ai_backend.get_provider("openai"), OpenAIProvider)
-=======
-from scripts.ai_providers.loader import get_provider  # noqa: E402
-
-
-class ProviderPluginTest(unittest.TestCase):
-    def test_discovery_and_generate(self):
-        openai = get_provider("openai")
-        llama = get_provider("local-llama")
-        self.assertEqual(openai.generate("hi"), "hi")
-        self.assertEqual(llama.generate("hi"), "mock-response")
->>>>>> main
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix AI provider loader with hot-reload logic
- clean up orchestrator and merge helper
- remove merge conflict markers in tests and documentation
- document remaining work items

## Testing
- `make lint`
- `pre-commit run --files scripts/ai_backend.py scripts/ai_providers/loader.py scripts/ai_providers/echo_provider.py scripts/merge_ai.py scripts/agent_orchestrator.py tests/python/test_ai_provider_plugins.py docs/ai_providers.md docs/REMAINING.md README.md providers.json`
- `pytest -q tests/python/test_ai_provider_loader.py tests/python/test_ai_provider_plugins.py`
- `make fast-test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6849091481948325ad08d4cb4dcb9c9d