### PR TITLE
Restore lint checks in CI and pin runtime deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install deps
-        run: pip install -r requirements.txt pre-commit
+        run: pip install -r requirements.txt -r requirements-dev.txt pre-commit
       - name: Run fast CI
         run: ./scripts/ci-fast.sh
 
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install deps
-        run: pip install -r requirements.txt pre-commit
+        run: pip install -r requirements.txt -r requirements-dev.txt pre-commit
       - name: Run full tests
         run: ./scripts/ci-full.sh
       - name: Set up buildx

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install deps
-        run: pip install -r requirements.txt pre-commit
+        run: pip install -r requirements.txt -r requirements-dev.txt pre-commit
       - name: Run full CI
         run: ./scripts/ci-full.sh
 

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ test-lifecycle:
 test-negative:
 	pytest -q tests/python/test_negative_paths.py
 
-fast-test:
+fast-test: lint
 	pytest -q -m "not slow" tests/python --ignore tests/python/test_ui_playwright.py
 
 lint:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,7 @@
 # Continuous Integration
 
-`ci-fast.sh` runs pre-commit hooks and `pytest -m "not slow"`.
+`ci-fast.sh` invokes `make fast-test` which runs `black --check`, `flake8` and
+`pytest -m "not slow"`.
 `ci-full.sh` builds the entire project, runs all tests and executes the demo
 container. Coverage is recorded and stored by `coverage_recorder.py`.
 
@@ -23,7 +24,8 @@ The workflow includes a Linux-only `smoke-test` job which invokes
 
 ### Updating dependencies
 
-Run the following to refresh your environment before executing the CI scripts:
+Edit `requirements.txt` and `requirements-dev.txt` to bump the minor versions
+using the `~=` constraint. Then refresh your environment with:
 
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Runtime dependency for `scripts/ai_backend.py`
-openai~=1.86.0
-cbor2~=5.6.5
-pytest-cov~=6.1.1
-cryptography~=45.0.4
-keyring~=25.6.0
-flask~=3.1.1
-PyYAML~=6.0.2
-psutil~=7.0.0
-fastapi~=0.115.12
+openai~=1.86
+cbor2~=5.6
+pytest-cov~=6.1
+cryptography~=45.0
+keyring~=25.6
+flask~=3.1
+PyYAML~=6.0
+psutil~=7.0
+fastapi~=0.115
 

--- a/scripts/ci-fast.sh
+++ b/scripts/ci-fast.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-pre-commit run --files $(git ls-files '*.py' '*.c' '*.h' '*.yaml')
-pytest -m "not slow" -q tests/python --ignore tests/python/test_ui_playwright.py
+make fast-test
 python -m compileall docs >/dev/null


### PR DESCRIPTION
## Summary
- run lint from `make fast-test`
- wire up linted fast CI script
- install dev requirements in CI
- document dependency bumps
- relax patch pins in `requirements.txt`

## Testing
- `make fast-test`
- `black --check scripts src tests/python`
- `flake8 scripts src tests/python`


------
https://chatgpt.com/codex/tasks/task_e_68492b7e69b0832590af49efb586cee7