### PR TITLE
Async queue and websocket updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,8 @@ flask~=3.1
 PyYAML~=6.0
 psutil~=7.0
 fastapi~=0.115
+redis~=5.3
+rq~=1.16
+uvicorn~=0.34
+websockets~=12.0
 

--- a/scripts/jobqueue/__init__.py
+++ b/scripts/jobqueue/__init__.py
@@ -1,0 +1,4 @@
+import importlib, sys
+# Ensure stdlib 'queue' module remains available when this package is on the path
+if 'queue' not in sys.modules or sys.modules['queue'].__spec__.origin.endswith(__file__):
+    sys.modules['queue'] = importlib.import_module('queue')

--- a/scripts/jobqueue/tasks.py
+++ b/scripts/jobqueue/tasks.py
@@ -1,0 +1,54 @@
+import json
+import os
+import time
+import redis
+from scripts.ai_providers import loader
+
+_redis = redis.Redis()
+
+
+def _status_path(branch_id: str) -> str:
+    base = os.path.expanduser(os.path.join("~/.aos/branches", str(branch_id)))
+    os.makedirs(base, exist_ok=True)
+    return os.path.join(base, "status.json")
+
+
+def update_status(branch_id: str, status: str, job_id: str | None = None) -> None:
+    path = _status_path(branch_id)
+    data = {}
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = {}
+    ts_key = f"{status.lower()}_at"
+    data["status"] = status
+    data[ts_key] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    if job_id is not None:
+        data["job_id"] = job_id
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+    try:
+        _redis.publish(f"branch:{branch_id}", json.dumps({"status": status}))
+    except Exception:
+        pass
+
+
+def provider_job(provider: str, prompt: str, branch_id: str) -> str:
+    """Run provider generation task."""
+    update_status(branch_id, "RUNNING")
+    try:
+        prov = loader.get_provider(provider)
+        result = prov.generate(prompt)
+        update_status(branch_id, "COMPLETE")
+        _redis.publish(
+            f"branch:{branch_id}", json.dumps({"status": "COMPLETE", "result": result})
+        )
+        return result
+    except Exception as exc:  # pragma: no cover - provider failure
+        update_status(branch_id, "FAILED")
+        _redis.publish(
+            f"branch:{branch_id}", json.dumps({"status": "FAILED", "error": str(exc)})
+        )
+        raise

--- a/scripts/jobqueue/worker.py
+++ b/scripts/jobqueue/worker.py
@@ -1,0 +1,13 @@
+import redis
+from rq import Worker, Queue, Connection
+
+
+def main():
+    redis_conn = redis.Redis()
+    with Connection(redis_conn):
+        worker = Worker([Queue()])
+        worker.work()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/coverage.py
+++ b/src/api/coverage.py
@@ -4,6 +4,7 @@ import os
 from fastapi import FastAPI, Response
 import yaml
 from scripts import aos_audit as audit
+from src.service.queue import load_status
 
 app = FastAPI()
 
@@ -42,5 +43,9 @@ def get_coverage(id: str, response: Response):
     threshold = _load_threshold()
     if hist and threshold and hist[-1]["lines"] < threshold:
         response.headers["X-Coverage-Below-Threshold"] = "true"
+    status = load_status(id).get("status")
     audit.log("get_coverage", branch=id, user="api")
-    return {"coverage": hist, "threshold": threshold}
+    data = {"coverage": hist, "threshold": threshold}
+    if status is not None:
+        data["status"] = status
+    return data

--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from scripts.agent_orchestrator import get_stats
 from scripts import aos_audit as audit
 from fastapi.responses import JSONResponse
+from src.service.queue import load_status
 
 app = FastAPI()
 
@@ -18,5 +19,8 @@ def get_metrics(id: str):
         return JSONResponse(status_code=502, content={"error": str(exc)})
     if data is None:
         raise HTTPException(status_code=404, detail="branch not found")
+    status = load_status(id).get("status")
+    if status is not None:
+        data["status"] = status
     audit.log("get_metrics", branch=id, user="api")
     return data

--- a/src/api/ws.py
+++ b/src/api/ws.py
@@ -1,0 +1,30 @@
+import asyncio
+import json
+import redis
+from fastapi import FastAPI, WebSocket
+from src.service.queue import load_status
+
+app = FastAPI()
+
+
+@app.websocket("/ws/branches/{id}")
+async def branch_ws(ws: WebSocket, id: str):
+    await ws.accept()
+    r = redis.Redis()
+    pubsub = r.pubsub()
+    channel = f"branch:{id}"
+    pubsub.subscribe(channel)
+    status = load_status(id).get("status")
+    if status is not None:
+        await ws.send_text(json.dumps({"status": status}))
+    try:
+        while True:
+            message = pubsub.get_message(timeout=1)
+            if message and message["type"] == "message":
+                await ws.send_text(message["data"].decode())
+            await asyncio.sleep(0.1)
+    except Exception:
+        pass
+    finally:
+        pubsub.close()
+        await ws.close()

--- a/src/service/queue.py
+++ b/src/service/queue.py
@@ -1,0 +1,31 @@
+import json
+import os
+import sys
+import importlib
+
+if 'queue' in sys.modules and getattr(sys.modules['queue'], '__file__', '').startswith(os.path.join(os.path.dirname(__file__), '..', 'scripts', 'queue')):
+    del sys.modules['queue']
+
+import redis
+from rq import Queue
+from scripts.jobqueue import tasks
+
+_redis = redis.Redis()
+_queue = Queue(connection=_redis)
+
+
+def enqueue_provider_job(branch_id: str, provider: str, prompt: str) -> str:
+    job = _queue.enqueue(tasks.provider_job, provider, prompt, branch_id)
+    tasks.update_status(branch_id, "QUEUED", job.id)
+    return job.id
+
+
+def load_status(branch_id: str) -> dict:
+    path = os.path.expanduser(os.path.join("~/.aos/branches", str(branch_id), "status.json"))
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return {}

--- a/tests/python/test_queue_integration.py
+++ b/tests/python/test_queue_integration.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+import subprocess
+import time
+import unittest
+
+import websockets
+from fastapi.testclient import TestClient
+
+from src.api.metrics import app as metrics_app
+from src.api.coverage import app as coverage_app
+from src.service import queue
+from scripts import agent_orchestrator
+
+
+class QueueIntegrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.redis_proc = subprocess.Popen(["redis-server", "--port", "6379", "--daemonize", "yes"])
+        time.sleep(0.5)
+        cls.worker_proc = subprocess.Popen(["python", "scripts/jobqueue/worker.py"])
+        time.sleep(0.5)
+        cls.ws_proc = subprocess.Popen([
+            "uvicorn",
+            "src.api.ws:app",
+            "--port",
+            "8765",
+            "--log-level",
+            "critical",
+        ])
+        time.sleep(1)
+        agent_orchestrator.branch_stats["99"] = {
+            "pending_tasks": 0,
+            "cpu_pct": 0.0,
+            "mem_pct": 0.0,
+            "history": [{"timestamp": "t"}],
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.worker_proc.terminate()
+        cls.worker_proc.wait()
+        cls.ws_proc.terminate()
+        cls.ws_proc.wait()
+        subprocess.Popen(["redis-cli", "shutdown"]).wait()
+
+    def test_queue_lifecycle(self):
+        queue.enqueue_provider_job("99", "echo", "hello")
+
+        async def _collect():
+            async with websockets.connect("ws://localhost:8765/ws/branches/99") as ws:
+                msgs = []
+                for _ in range(3):
+                    msg = await ws.recv()
+                    msgs.append(msg)
+                    if "COMPLETE" in msg:
+                        break
+                return msgs
+
+        msgs = asyncio.get_event_loop().run_until_complete(_collect())
+        self.assertTrue(any("COMPLETE" in m for m in msgs))
+        status = queue.load_status("99").get("status")
+        self.assertEqual(status, "COMPLETE")
+        client = TestClient(metrics_app)
+        resp = client.get("/branches/99/metrics")
+        if resp.status_code == 200:
+            self.assertEqual(resp.json().get("status"), "COMPLETE")
+        resp2 = TestClient(coverage_app).get("/branches/99/coverage-history")
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(resp2.json().get("status"), "COMPLETE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement Redis RQ job queue
- store branch status and push progress via websocket
- expose queue helpers and websocket endpoint
- include branch status in metrics and coverage APIs
- add integration test for queue workflow

## Testing
- `pytest -q tests/python/test_api_metrics.py`
- `pytest -q` *(fails: KeyboardInterrupt while tearing down server)*

------
https://chatgpt.com/codex/tasks/task_e_68492d87c4e88325bdc13bf948e65256