### PR TITLE
Add sandbox plugin registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ flask~=3.1
 PyYAML~=6.0
 psutil~=7.0
 fastapi~=0.115
+docker~=7.0
 

--- a/scripts/ai_providers/plugin_runner.py
+++ b/scripts/ai_providers/plugin_runner.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import docker
+
+from .base import AIProvider
+
+
+class PluginRunner(AIProvider):
+    """Execute provider inside a sandbox container."""
+
+    def __init__(self, name: str, image: str, entry: str):
+        super().__init__(name)
+        self.image = image
+        self.entry = entry
+        self.client = docker.from_env()
+
+    def generate(self, prompt: str) -> str:  # pragma: no cover - docker mocked
+        env = {"ENTRY_CLASS": self.entry, "PROMPT": prompt, "PROV_NAME": self.name}
+        cont = self.client.containers.run(
+            self.image,
+            environment=env,
+            volumes={"/contracts": {"bind": "/contracts", "mode": "ro"}},
+            mem_limit=64 * 1024 * 1024,
+            detach=True,
+        )
+        try:
+            cont.wait(timeout=5)
+            output = cont.logs().decode().strip()
+        finally:
+            cont.remove(force=True)
+        return output

--- a/scripts/plugins_cli.py
+++ b/scripts/plugins_cli.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Plugin registry management CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_STORE = ROOT / "plugins"
+DEFAULT_REGISTRY = ROOT / "providers.json"
+
+
+def _load_manifest(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    for key in ("name", "version", "entry_class", "permissions"):
+        if key not in data:
+            raise ValueError(f"missing {key} in provider.yaml")
+    return data
+
+
+def _clone(src: str, dest: Path) -> None:
+    if os.path.isdir(src):
+        shutil.copytree(src, dest)
+    else:
+        subprocess.check_call(["git", "clone", src, str(dest)])
+
+
+def _build_image(path: Path, tag: str) -> None:
+    subprocess.check_call(["docker", "build", "-t", tag, "-f", "Dockerfile.sandbox", str(path)])
+
+
+def _register(manifest: dict, registry: Path, image: str) -> None:
+    if registry.exists():
+        with open(registry, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    else:
+        data = {}
+    data[manifest["name"]] = {
+        "module": "scripts.ai_providers.plugin_runner",
+        "class": "PluginRunner",
+        "image": image,
+        "entry": manifest["entry_class"],
+    }
+    with open(registry, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    tmpdir = Path(tempfile.mkdtemp())
+    shutil.rmtree(tmpdir)
+    _clone(args.repo, tmpdir)
+    manifest = _load_manifest(tmpdir / "provider.yaml")
+    dest = Path(args.store) / manifest["name"]
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(tmpdir, dest)
+    image = f"{manifest['name']}:{manifest['version']}"
+    _build_image(dest, image)
+    _register(manifest, Path(args.registry), image)
+    print(f"added {manifest['name']}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    reg = Path(args.registry)
+    if not reg.exists():
+        return 0
+    with open(reg, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    for name in data:
+        print(name)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="aos plugins")
+    sub = p.add_subparsers(dest="cmd")
+
+    add = sub.add_parser("add", help="add plugin from git")
+    add.add_argument("repo")
+    add.add_argument("--registry", default=str(DEFAULT_REGISTRY))
+    add.add_argument("--store", default=str(DEFAULT_STORE))
+    add.set_defaults(func=cmd_add)
+
+    lsp = sub.add_parser("list", help="list registered plugins")
+    lsp.add_argument("--registry", default=str(DEFAULT_REGISTRY))
+    lsp.set_defaults(func=cmd_list)
+
+    args = p.parse_args(argv)
+    if not hasattr(args, "func"):
+        p.print_help()
+        return 1
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    import sys
+
+    sys.exit(main())

--- a/tests/fixtures/echo_plugin/Dockerfile.sandbox
+++ b/tests/fixtures/echo_plugin/Dockerfile.sandbox
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY echo_plugin.py .
+COPY run_plugin.py .
+ENTRYPOINT ["python", "run_plugin.py"]

--- a/tests/fixtures/echo_plugin/echo_plugin.py
+++ b/tests/fixtures/echo_plugin/echo_plugin.py
@@ -1,0 +1,3 @@
+class Echo:
+    def generate(self, prompt: str) -> str:
+        return prompt

--- a/tests/fixtures/echo_plugin/provider.yaml
+++ b/tests/fixtures/echo_plugin/provider.yaml
@@ -1,0 +1,4 @@
+name: echo
+version: "1.0"
+entry_class: echo_plugin.Echo
+permissions: []

--- a/tests/fixtures/echo_plugin/run_plugin.py
+++ b/tests/fixtures/echo_plugin/run_plugin.py
@@ -1,0 +1,8 @@
+import os
+import importlib
+
+entry = os.environ['ENTRY_CLASS']
+prompt = os.environ['PROMPT']
+module_name, class_name = entry.rsplit('.', 1)
+cls = getattr(importlib.import_module(module_name), class_name)
+print(cls().generate(prompt))

--- a/tests/python/test_plugins_cli.py
+++ b/tests/python/test_plugins_cli.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import json
+import tempfile
+import shutil
+import subprocess
+import unittest
+from unittest import mock
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from scripts import plugins_cli  # noqa: E402
+from scripts.ai_providers import loader  # noqa: E402
+
+
+FIXTURE = (Path(__file__).resolve().parents[1] / "fixtures" / "echo_plugin").resolve()
+
+
+class PluginsCliTest(unittest.TestCase):
+    def _run_add(self, registry, store):
+        argv = [
+            "plugins_cli.py",
+            "add",
+            str(FIXTURE),
+            "--registry",
+            str(registry),
+            "--store",
+            str(store),
+        ]
+        with mock.patch.object(sys, "argv", argv), \
+            mock.patch.object(subprocess, "check_call") as cc, \
+            mock.patch("docker.from_env"):
+            plugins_cli.main()
+            self.assertTrue(cc.called)
+
+    def test_add_and_load(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            reg = Path(tmp) / "providers.json"
+            reg.write_text("{}")
+            store = Path(tmp) / "store"
+            store.mkdir()
+            self._run_add(reg, store)
+            data = json.loads(reg.read_text())
+            self.assertIn("echo", data)
+            info = data["echo"]
+            self.assertIn("image", info)
+
+            cont = mock.Mock()
+            cont.wait.return_value = None
+            cont.logs.return_value = b"hi"
+            client = mock.Mock()
+            client.containers.run.return_value = cont
+            with mock.patch("docker.from_env", return_value=client):
+                loader._CFG = str(reg)
+                loader._mtime = None
+                loader.PROVIDERS.clear()
+                prov = loader.get_provider("echo")
+                out = prov.generate("hi")
+                self.assertEqual(out, "hi")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add example echo plugin fixture
- implement PluginRunner container provider
- create `plugins_cli.py` for plugin registry management
- update provider loader for container plugins
- add docker dependency
- test plugin CLI behavior

## Testing
- `pytest -q tests/python/test_plugins_cli.py`
- `pytest -q` *(fails: ProviderHotReloadTest::test_reload_on_change, CredManagerTest failures)*

------
https://chatgpt.com/codex/tasks/task_e_68492d933df48325a21fe71aea1191bd