### PR TITLE
Provider guard, circuit breaker and secrets CLI

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -556,6 +556,11 @@ Next agent must:
 - Restored flake8 failure on CI and pinned dev dependencies.
 - Documented dependency bumps note in README.
 
+## [2025-06-12 02:00 UTC] provider safety & secrets [agent-mem]
+- Added flake8 plugin and pytest warning for missing provider generate().
+- Implemented metrics circuit breaker with cached data fallback.
+- Added Vault-backed secrets CLI with .env fallback.
+
 ## Open Tasks
 - Expand developer documentation and keep diagrams updated.
 - Review all subsystems for missing comments; use `AosError` consistently.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -30,3 +30,15 @@ New actions recorded:
 - `get_metrics` – fetching branch metrics
 - `get_coverage` – retrieving coverage history
 - `merge_blocked` – merge denied due to low coverage
+
+## Secrets Management
+
+The `aos secrets` command stores sensitive values either in HashiCorp Vault
+(if `VAULT_ADDR` is set) or a local `.env` file under `~/.aos/`. Example:
+
+```bash
+aos secrets set api_key abc123
+aos secrets get api_key
+```
+
+When Vault is unreachable the CLI falls back to the `.env` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,5 @@ packages = ["scripts"]
 
 [project.scripts]
 aos-audit = "scripts.aos_audit:main"
+[project.entry-points."flake8.extension"]
+PG001 = "scripts.flake8_provider:ProviderGenerateChecker"

--- a/scripts/agent_orchestrator.py
+++ b/scripts/agent_orchestrator.py
@@ -4,6 +4,7 @@ import queue
 import subprocess
 import threading
 import time
+from collections import OrderedDict
 import shlex
 import importlib
 from dataclasses import dataclass
@@ -29,17 +30,51 @@ TASKS_PER_AGENT = int(os.environ.get("TASKS_PER_AGENT", "3"))
 METRICS: Dict[int, Dict[str, float]] = {}
 branch_stats: Dict[str, Dict] = {}
 _stats_lock = threading.Lock()
+_stats_cache: "OrderedDict[str, Dict]" = OrderedDict()
+_cache_limit = 20
+_failure_count = 0
+_break_until = 0.0
 
 
 def get_stats(branch_id: str) -> Dict | None:
-    """Return latest stats for ``branch_id`` copied from memory."""
-    with _stats_lock:
-        data = branch_stats.get(str(branch_id))
-        return json.loads(json.dumps(data)) if data else None
+    """Return latest stats for ``branch_id`` copied from memory.
+
+    Implements a simple circuit breaker to avoid repeated failures.
+    Successful calls populate an LRU cache used on failure paths.
+    """
+    global _failure_count, _break_until
+
+    now = time.time()
+    if now < _break_until:
+        raise RuntimeError("metrics temporarily unavailable")
+    try:
+        with _stats_lock:
+            data = branch_stats.get(str(branch_id))
+            result = json.loads(json.dumps(data)) if data else None
+        if result is not None:
+            if len(_stats_cache) >= _cache_limit:
+                _stats_cache.popitem(last=False)
+            _stats_cache[str(branch_id)] = result
+        _failure_count = 0
+        return result
+    except Exception as exc:
+        _failure_count += 1
+        if _failure_count >= 3:
+            _break_until = now + 5
+        raise RuntimeError(str(exc))
+
+
+def get_cached_stats(branch_id: str) -> Dict | None:
+    """Return cached stats for ``branch_id`` if available."""
+    return _stats_cache.get(str(branch_id))
 
 
 try:
-    psutil = importlib.import_module("psutil") if importlib.util.find_spec("psutil") else None
+    psutil = (
+        importlib.import_module("psutil")
+        if importlib.util.find_spec("psutil")
+        else None
+    )
 except Exception:  # pragma: no cover - optional dependency
     psutil = None
 PROVIDERS: Dict[str, AIProvider] = loader.PROVIDERS
@@ -296,9 +331,7 @@ def run_tasks(branch_id: int) -> Iterable[Dict[str, str]]:
             rec["mem_pct"] = mem_val
             rec.setdefault("history", []).append(
                 {
-                    "timestamp": time.strftime(
-                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-                    ),
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                     "pending_tasks": pending,
                     "cpu_pct": cpu_val,
                     "mem_pct": mem_val,

--- a/scripts/ai_providers/base.py
+++ b/scripts/ai_providers/base.py
@@ -8,6 +8,14 @@ from abc import ABC, abstractmethod
 class AIProvider(ABC):
     """Abstract provider interface."""
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # warn if subclass fails to override generate()
+        if cls.generate is AIProvider.generate:
+            import warnings
+
+            warnings.warn(f"{cls.__name__} must override generate()", RuntimeWarning)
+
     def __init__(self, name: str):
         self.name = name
 

--- a/scripts/cli/secrets.py
+++ b/scripts/cli/secrets.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Minimal secrets helper using ai_cred_manager."""
+
+import argparse
+from scripts import ai_cred_manager as cm
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Manage secrets")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("set")
+    s.add_argument("key")
+    s.add_argument("value")
+
+    g = sub.add_parser("get")
+    g.add_argument("key")
+
+    args = ap.parse_args()
+
+    if args.cmd == "set":
+        cm.vault_set(args.key, args.value)
+    elif args.cmd == "get":
+        val = cm.vault_get(args.key)
+        print(val)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/flake8_provider.py
+++ b/scripts/flake8_provider.py
@@ -1,0 +1,26 @@
+import ast
+
+
+class ProviderGenerateChecker:
+    """Flake8 checker ensuring AI providers override generate()."""
+
+    name = "provider-generate-checker"
+    version = "0.1"
+
+    def __init__(self, tree):
+        self.tree = tree
+
+    def run(self):
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ClassDef):
+                bases = [
+                    getattr(base, "id", getattr(base, "attr", None))
+                    for base in node.bases
+                ]
+                if "AIProvider" in bases:
+                    if not any(
+                        isinstance(n, ast.FunctionDef) and n.name == "generate"
+                        for n in node.body
+                    ):
+                        msg = "PG001 provider missing generate() override"
+                        yield (node.lineno, node.col_offset, msg, type(self))

--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException
-from scripts.agent_orchestrator import get_stats
+from scripts.agent_orchestrator import get_stats, get_cached_stats
 from scripts import aos_audit as audit
 from fastapi.responses import JSONResponse
 
@@ -15,7 +15,10 @@ def get_metrics(id: str):
     try:
         data = get_stats(id)
     except RuntimeError as exc:
-        return JSONResponse(status_code=502, content={"error": str(exc)})
+        cached = get_cached_stats(id)
+        return JSONResponse(
+            status_code=502, content={"error": str(exc), "data": cached}
+        )
     if data is None:
         raise HTTPException(status_code=404, detail="branch not found")
     audit.log("get_metrics", branch=id, user="api")

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -2,4 +2,32 @@ import os
 import sys
 
 # Ensure the repository root is on the path so `import scripts.*` works
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+)  # noqa: E402
+
+import importlib  # noqa: E402
+import inspect  # noqa: E402
+import pkgutil  # noqa: E402
+import warnings  # noqa: E402
+from scripts.ai_providers.base import AIProvider  # noqa: E402
+
+
+def pytest_configure(config):
+    provider_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "scripts", "ai_providers"
+    )
+    modules = []
+    for _, modname, _ in pkgutil.iter_modules([provider_path]):
+        try:
+            modules.append(importlib.import_module(f"scripts.ai_providers.{modname}"))
+        except Exception:
+            continue
+    missing = []
+    for mod in modules:
+        for _, obj in inspect.getmembers(mod, inspect.isclass):
+            if issubclass(obj, AIProvider) and obj is not AIProvider:
+                if obj.generate is AIProvider.generate:
+                    missing.append(obj.__name__)
+    if missing:
+        warnings.warn(f"missing generate() in: {', '.join(missing)}")

--- a/tests/python/test_api_failure.py
+++ b/tests/python/test_api_failure.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest import mock
+from fastapi.testclient import TestClient
+
+from src.api.metrics import app
+import scripts.agent_orchestrator as ao
+
+
+class MetricsCircuitBreakerTest(unittest.TestCase):
+    def test_cached_on_failure(self):
+        ao._stats_cache.clear()
+        ao._stats_cache["1"] = {"v": 1}
+        with mock.patch("src.api.metrics.get_stats", side_effect=RuntimeError("boom")):
+            client = TestClient(app)
+            fail = client.get("/branches/1/metrics")
+            self.assertEqual(fail.status_code, 502)
+            self.assertEqual(fail.json(), {"error": "boom", "data": {"v": 1}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_metrics_failure.py
+++ b/tests/python/test_metrics_failure.py
@@ -11,7 +11,7 @@ class MetricsFailureTest(unittest.TestCase):
             client = TestClient(app)
             resp = client.get("/branches/1/metrics")
             self.assertEqual(resp.status_code, 502)
-            self.assertEqual(resp.json(), {"error": "boom"})
+            self.assertEqual(resp.json()["error"], "boom")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_provider_contract.py
+++ b/tests/python/test_provider_contract.py
@@ -1,0 +1,33 @@
+import importlib
+import inspect
+import os
+import pkgutil
+import unittest
+
+from scripts.ai_providers.base import AIProvider
+
+
+class ProviderContract(unittest.TestCase):
+    def test_generate_overridden(self):
+        provider_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "scripts", "ai_providers"
+        )
+        modules = []
+        for _, modname, _ in pkgutil.iter_modules([provider_path]):
+            try:
+                modules.append(
+                    importlib.import_module(f"scripts.ai_providers.{modname}")
+                )
+            except Exception:
+                continue
+        missing = []
+        for mod in modules:
+            for _, obj in inspect.getmembers(mod, inspect.isclass):
+                if issubclass(obj, AIProvider) and obj is not AIProvider:
+                    if obj.generate is AIProvider.generate:
+                        missing.append(obj.__name__)
+        self.assertFalse(missing, f"providers missing generate(): {', '.join(missing)}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add flake8 plugin and pytest hook to detect providers missing `generate`
- integrate HashiCorp Vault fallback and provide `aos secrets` helper
- wrap metrics stats in simple circuit breaker with cached data
- document secrets command
- record work in meta log

## Testing
- `make fast-test`
- `pytest -q tests/python/test_provider_contract.py tests/python/test_api_failure.py`
- `PYTHONPATH=. python scripts/cli/secrets.py set foo bar && PYTHONPATH=. python scripts/cli/secrets.py get foo`

------
https://chatgpt.com/codex/tasks/task_e_68492d80fccc8325a79e5d08c4760a3f