### PR TITLE
feat(obs): Prometheus exporter + Grafana dash [agent-mem]

### DIFF
--- a/observability/grafana/aos_queue_dashboard.json
+++ b/observability/grafana/aos_queue_dashboard.json
@@ -1,0 +1,20 @@
+{
+  "title": "AOS Queue Metrics",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Queue Length",
+      "targets": [{"expr": "queue_len"}]
+    },
+    {
+      "type": "graph",
+      "title": "Job Latency",
+      "targets": [{"expr": "job_latency"}]
+    },
+    {
+      "type": "graph",
+      "title": "Worker Count",
+      "targets": [{"expr": "worker_count"}]
+    }
+  ]
+}

--- a/src/observability/prom_exporter.py
+++ b/src/observability/prom_exporter.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, Response
+import time
+import redis
+from rq import Queue, Worker
+
+app = FastAPI()
+_r = redis.Redis()
+_q = Queue(connection=_r)
+
+
+def _queue_len() -> int:
+    try:
+        return len(_q)
+    except Exception:
+        return 0
+
+
+def _worker_count() -> int:
+    try:
+        return len(Worker.all(connection=_r))
+    except Exception:
+        return 0
+
+
+def _job_latency() -> float:
+    try:
+        jobs = _q.jobs
+        if not jobs:
+            return 0.0
+        total = sum(time.time() - j.enqueued_at.timestamp() for j in jobs)
+        return total / len(jobs)
+    except Exception:
+        return 0.0
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    q_len = _queue_len()
+    workers = _worker_count()
+    latency = _job_latency()
+    body = (
+        "# TYPE queue_len gauge\n"
+        f"queue_len {q_len}\n"
+        "# TYPE job_latency gauge\n"
+        f"job_latency {latency}\n"
+        "# TYPE worker_count gauge\n"
+        f"worker_count {workers}\n"
+    )
+    return Response(content=body, media_type="text/plain; version=0.0.4")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, port=8000)

--- a/tests/python/test_prometheus.py
+++ b/tests/python/test_prometheus.py
@@ -1,0 +1,24 @@
+import unittest
+from fastapi.testclient import TestClient
+
+from src.observability.prom_exporter import app
+
+
+class PrometheusExporterTest(unittest.TestCase):
+    def test_metrics_keys(self):
+        client = TestClient(app)
+        res = client.get("/metrics")
+        self.assertEqual(res.status_code, 200)
+        data = {}
+        for line in res.text.splitlines():
+            if line.startswith("#") or not line.strip():
+                continue
+            k, _ = line.split(None, 1)
+            data[k] = True
+        self.assertIn("queue_len", data)
+        self.assertIn("job_latency", data)
+        self.assertIn("worker_count", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose queue metrics with a small FastAPI exporter
- add a basic Grafana dashboard
- ensure metrics endpoint returns expected keys

## Testing
- `pytest -q tests/python/test_prometheus.py`
- `python -m uvicorn src.observability.prom_exporter:app --port 8000 --log-level critical &`
- `curl -s http://localhost:8000/metrics | grep queue_len`

------
https://chatgpt.com/codex/tasks/task_e_68493b8d7a34832594a50f936a150f2b