### PR TITLE
Add init wizard and marketplace UI

### DIFF
--- a/scripts/cli/init.py
+++ b/scripts/cli/init.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Interactive setup wizard creating .env and docker-compose.yml."""
+
+import os
+
+ENV_FILE = ".env"
+COMPOSE_FILE = "docker-compose.yml"
+
+DC_TEMPLATE = """version: "3"
+services:
+  aos:
+    image: aos:latest
+    env_file:
+      - .env
+    ports:
+      - "5000:5000"
+      - "8080:8080"
+    privileged: true
+"""
+
+
+def main() -> int:
+    redis = input("Redis URL [redis://localhost:6379]: ") or "redis://localhost:6379"
+    vault = input("Vault address [http://localhost:8200]: ") or "http://localhost:8200"
+    with open(ENV_FILE, "w", encoding="utf-8") as fh:
+        fh.write(f"AOS_REDIS_URL={redis}\n")
+        fh.write(f"VAULT_ADDR={vault}\n")
+    if not os.path.exists(COMPOSE_FILE):
+        with open(COMPOSE_FILE, "w", encoding="utf-8") as fh:
+            fh.write(DC_TEMPLATE)
+    print("Configuration written to .env and docker-compose.yml")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ui/src/__tests__/marketplace.test.tsx
+++ b/ui/src/__tests__/marketplace.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Marketplace from "../pages/Marketplace";
+
+test("renders marketplace header", () => {
+  render(<Marketplace />);
+  expect(screen.getByText(/Marketplace/i)).toBeInTheDocument();
+});

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import BranchList from "./pages/BranchList";
 import BranchDetail from "./pages/BranchDetail";
 import AdminPage from "./pages/AdminPage";
+import Marketplace from "./pages/Marketplace";
 import RoleGuard from "./RoleGuard";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -12,6 +13,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <Routes>
         <Route path="/" element={<BranchList />} />
         <Route path="/branches/:id" element={<BranchDetail />} />
+        <Route path="/marketplace" element={<Marketplace />} />
         <Route
           path="/admin"
           element={

--- a/ui/src/pages/BranchList.tsx
+++ b/ui/src/pages/BranchList.tsx
@@ -28,6 +28,9 @@ export default function BranchList() {
         ))}
       </ul>
       {cursor && <button onClick={load}>More</button>}
+      <p>
+        <a href="/marketplace">Marketplace</a>
+      </p>
     </div>
   );
 }

--- a/ui/src/pages/Marketplace.tsx
+++ b/ui/src/pages/Marketplace.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import api from "../services/api";
+
+const providers = [
+  { name: "OpenAI", repo: "https://github.com/aos/openai-plugin.git" },
+  { name: "Local Llama", repo: "https://github.com/aos/local-llama.git" },
+  { name: "Echo", repo: "https://github.com/aos/echo-plugin.git" },
+];
+
+export default function Marketplace() {
+  const install = async (repo: string) => {
+    try {
+      await api.installPlugin(repo);
+      alert("Installed " + repo);
+    } catch {
+      alert("Install failed");
+    }
+  };
+
+  return (
+    <div>
+      <h2>Marketplace</h2>
+      <div style={{ display: "flex", gap: "1rem" }}>
+        {providers.map((p) => (
+          <div key={p.repo} style={{ border: "1px solid #ccc", padding: "1rem" }}>
+            <h3>{p.name}</h3>
+            <button onClick={() => install(p.repo)}>Install</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -51,4 +51,14 @@ export async function getBranches(limit = 10, cursor?: string) {
   return res.json();
 }
 
-export default { login, refresh, getBranches, getRole };
+export async function installPlugin(repo: string) {
+  const res = await fetch("/plugins/install", {
+    method: "POST",
+    headers: { ...headers(), "Content-Type": "application/json" },
+    body: JSON.stringify({ repo }),
+  });
+  if (!res.ok) throw new Error("install failed");
+  return res.json();
+}
+
+export default { login, refresh, getBranches, installPlugin, getRole };


### PR DESCRIPTION
## Summary
- build interactive `aos init` wizard to create `.env` and docker-compose files
- expand UI with marketplace page
- show link to marketplace on branch list
- allow installing plugins from the UI
- add marketplace unit test

## Testing
- `npm --prefix ui test` *(fails: jest not found)*
- `pytest -q tests/python` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684943db82208325ae9dd77c5f7b3be5