### PR TITLE
feat(rollback): endpoint + UI + e2e [agent-mem]

### DIFF
--- a/tests/e2e/rollback.spec.ts
+++ b/tests/e2e/rollback.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test("rollback button triggers confirm", async ({ page }) => {
+  await page.route("**/branches/1/rollback", route => {
+    route.fulfill({ status: 200, body: "{\"rolled_back\":true}" });
+  });
+  await page.goto("http://localhost:8000/branches/1");
+  const dialogPromise = page.waitForEvent("dialog");
+  await page.click("text=Rollback");
+  const dialog = await dialogPromise;
+  await dialog.accept();
+  await expect(page.locator("text=Status")).toBeVisible();
+});

--- a/ui/src/pages/BranchDetail.tsx
+++ b/ui/src/pages/BranchDetail.tsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom";
 export default function BranchDetail() {
   const { id } = useParams();
   const [data, setData] = useState<any[]>([]);
+  const [status, setStatus] = useState<string>("unknown");
 
   useEffect(() => {
     if (!id) return;
@@ -29,9 +30,29 @@ export default function BranchDetail() {
     };
   }, [id]);
 
+  useEffect(() => {
+    if (!id) return;
+    const ws = new WebSocket(`ws://${window.location.host}/ws/branches/${id}`);
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.status) setStatus(msg.status);
+      } catch {}
+    };
+    return () => ws.close();
+  }, [id]);
+
+  const rollback = async () => {
+    if (!id) return;
+    if (!confirm("Rollback branch?")) return;
+    await fetch(`/branches/${id}/rollback`, { method: "POST" });
+  };
+
   return (
     <div>
       <h2>Branch {id}</h2>
+      <p>Status: {status}</p>
+      <button onClick={rollback}>Rollback</button>
       <LineChart width={300} height={200} data={data}>
         <Line type="monotone" dataKey="cpu" stroke="#8884d8" />
         <Line type="monotone" dataKey="coverage" stroke="#82ca9d" />


### PR DESCRIPTION
## Summary
- add job param persistence to queue service
- backup branches JSON on merge and implement rollback endpoint
- expose rollback button in dashboard
- create Playwright e2e test for rollback

## Testing
- `pre-commit run --files src/api/branches.py src/service/queue.py ui/src/pages/BranchDetail.tsx tests/e2e/rollback.spec.ts`
- `pytest -q tests/python/test_task_model.py`
- `pytest -q tests/python/test_queue_integration.py` *(fails: FileNotFoundError: 'redis-server')*

------
https://chatgpt.com/codex/tasks/task_e_684943d547d88325969d8fbb13e1bee3