### PR TITLE
Security docs and autoscaler config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Autoscaler settings
+AOS_RQ_MIN=1
+AOS_RQ_MAX=10
+CHECK_INTERVAL=5

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,3 +10,4 @@
 - [Agent Log](../AGENT.md)
 - [Patch Log](../PATCHLOG.md)
 - [Roadmap](../ROADMAP.md)
+- [Configuration](configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,21 @@
+# Configuration
+
+## Autoscaler Environment Variables
+
+The autoscaler daemon polls Redis and adjusts the number of worker
+containers. Tune its behaviour using the following environment
+variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AOS_RQ_MIN` | Minimum number of workers to keep running | `1` |
+| `AOS_RQ_MAX` | Maximum number of workers allowed | `10` |
+| `CHECK_INTERVAL` | Seconds between queue length checks | `5` |
+
+Example `.env` fragment:
+
+```env
+AOS_RQ_MIN=2
+AOS_RQ_MAX=8
+CHECK_INTERVAL=10
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,3 +22,15 @@ Audit events are recorded as newline-delimited JSON in
 `/var/log/aos-audit.log` with the fields `timestamp`, `user`, `action`,
 `resource` and `result`. Use `aos-audit show` with filtering options to
 inspect the log.
+
+### Updating sandbox seccomp profile
+
+Sandboxed plugins and services run under a seccomp policy defined in
+`profiles/aos-seccomp.json`. The profile uses a permissive default action and
+denies only dangerous syscalls such as `kill`. Edit this file to tighten the
+sandbox and restart the service to apply changes. The format matches Docker's
+seccomp JSON, so you can test updates with:
+
+```bash
+$ docker run --rm --security-opt seccomp=profiles/aos-seccomp.json your_image
+```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'firefox', use: { browserName: 'firefox' } },
+    { name: 'webkit', use: { browserName: 'webkit' } },
+  ],
+});

--- a/src/observability/prom_exporter.py
+++ b/src/observability/prom_exporter.py
@@ -4,6 +4,8 @@ import time
 import redis
 from rq import Queue, Worker
 
+__all__ = ["expose_metrics"]
+
 app = FastAPI()
 apply_security_headers(app)
 _r = redis.Redis()
@@ -49,6 +51,11 @@ def metrics() -> Response:
         f"worker_count {workers}\n"
     )
     return Response(content=body, media_type="text/plain; version=0.0.4")
+
+
+def expose_metrics() -> FastAPI:
+    """Return the FastAPI app exposing Prometheus metrics."""
+    return app
 
 
 if __name__ == "__main__":

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "lint": "echo lint",
     "e2e": "playwright test",
+    "test:e2e": "playwright test",
     "format": "prettier --write \"src/**/*.{js,ts,jsx,tsx}\""
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- document aos-seccomp.json update process
- describe autoscaler environment variables
- expose metrics app from prom_exporter
- sample env file and Playwright multi-browser config

## Testing
- `make fast-test` *(fails: KeyboardInterrupt, no tests run)*
- `npm run test:e2e` *(fails: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68494aeed2c48325a41e519ed53bf834