### PR TITLE
Improve branch VM demo script robustness

### DIFF
--- a/examples/branch_vm_demo.sh
+++ b/examples/branch_vm_demo.sh
@@ -1,3 +1,28 @@
 #!/bin/sh
 # Demo for hypervisor-backed branches
-./build/branch_vm_demo
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [--help] [branch]" >&2
+  echo "Run branch_vm_demo with optional branch name." >&2
+}
+
+branch="demo"
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      branch="$1"
+      ;;
+  esac
+fi
+
+if ! command -v qemu-system-x86_64 >/dev/null 2>&1; then
+  echo "qemu-system-x86_64 not found. Install QEMU to run this demo." >&2
+  exit 1
+fi
+
+./build/branch_vm_demo "$branch"


### PR DESCRIPTION
## Summary
- add error handling and simple argument parsing to `branch_vm_demo.sh`
- check that `qemu-system-x86_64` is installed before running the demo

## Testing
- `pre-commit run --files examples/branch_vm_demo.sh`
- `make test` *(fails: fatal error: bits/wordsize.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6852aa99a2d883259a7d5986977aa342