### PR TITLE
Implement AI init/process syscalls

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -22,6 +22,8 @@ typedef enum {
     SYS_LIST_BRANCH,   /* list all branches */
     SYS_AI_QUERY,      /* str_arg0 holds the prompt */
     SYS_AI_MODEL_INFO, /* request model metadata */
+    SYS_AI_INIT,       /* payload is model path */
+    SYS_AI_PROCESS,    /* process input payload */
     SYS_FS_OPEN,       /* open file str_arg0 with mode str_arg1 */
     SYS_FS_READ,       /* read int_arg1 bytes from fd int_arg0 */
     SYS_FS_WRITE,      /* write int_arg1 bytes from str_arg0 to fd int_arg0 */

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -11,5 +11,7 @@
 
 void syscall_init(IpcRing *shared);
 int sys_ai_query(const char *prompt, char *out, size_t outsz);
+int sys_ai_init(const char *model);
+int sys_ai_process(const char *input, size_t in_len, char *out, size_t out_sz);
 
 #endif /* SYSCALL_H */

--- a/src/ipc_host.c
+++ b/src/ipc_host.c
@@ -31,6 +31,16 @@ void ipc_host_handle(IpcRing *ring) {
         snprintf(resp->data, sizeof(resp->data), "OK");
         resp->retval = strlen(resp->data);
         break;
+    case SYS_AI_INIT:
+        log_message(LOG_INFO, "ai init %s", req->payload);
+        resp->retval = 0;
+        resp->data[0] = '\0';
+        break;
+    case SYS_AI_PROCESS:
+        log_message(LOG_INFO, "ai process %d bytes", req->int_arg0);
+        snprintf(resp->data, sizeof(resp->data), "processed");
+        resp->retval = strlen(resp->data);
+        break;
     case SYS_CREATE_BRANCH:
         resp->retval = sys_create_branch();
         break;

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -117,3 +117,43 @@ int sys_delete_branch(unsigned int branch_id) {
         usleep(1000);
     return ring->resp[idx].retval;
 }
+
+int sys_ai_init(const char *model) {
+    if (!ring)
+        return -1;
+    size_t idx = ring->head % IPC_RING_SIZE;
+    SyscallRequest *req = &ring->req[idx];
+    memset(req, 0, sizeof(*req));
+    req->id = SYS_AI_INIT;
+    strncpy(req->payload, model ? model : "", sizeof(req->payload) - 1);
+    req->payload[sizeof(req->payload) - 1] = '\0';
+    ring->head++;
+    while (ring->tail <= idx)
+        usleep(1000);
+    return ring->resp[idx].retval;
+}
+
+int sys_ai_process(const char *input, size_t in_len, char *out, size_t out_sz) {
+    if (!ring)
+        return -1;
+    size_t idx = ring->head % IPC_RING_SIZE;
+    SyscallRequest *req = &ring->req[idx];
+    memset(req, 0, sizeof(*req));
+    req->id = SYS_AI_PROCESS;
+    req->int_arg0 = (int32_t)in_len;
+    if (input) {
+        strncpy(req->payload, input, sizeof(req->payload) - 1);
+        req->payload[sizeof(req->payload) - 1] = '\0';
+    } else {
+        req->payload[0] = '\0';
+    }
+    ring->head++;
+    while (ring->tail <= idx)
+        usleep(1000);
+    SyscallResponse *resp = &ring->resp[idx];
+    if (out && out_sz) {
+        strncpy(out, resp->data, out_sz - 1);
+        out[out_sz - 1] = '\0';
+    }
+    return resp->retval;
+}

--- a/subsystems/ai/ai.c
+++ b/subsystems/ai/ai.c
@@ -4,6 +4,7 @@
  * Purpose: Source file.
  */
 #include "ai.h"
+#include "syscall.h"
 /* [2025-06-09 06:06 UTC] HTTP echo based AI stub
  * by: codex
  * Edge cases: network errors not handled, insecure HTTP parameters.
@@ -19,6 +20,9 @@ static char profile[32] = "default";
 void ai_init(const char *p) {
     if (p)
         strncpy(profile, p, sizeof(profile) - 1);
+    if (sys_ai_init("/models/default.bin") < 0)
+        strncpy(response, "init error", sizeof(response) - 1);
+    response[sizeof(response) - 1] = '\0';
     curl_global_init(CURL_GLOBAL_DEFAULT);
 }
 
@@ -137,3 +141,14 @@ const char *ai_get_provider(void) {
 }
 
 const char *ai_get_param(void) { return get_param(); }
+
+int ai_process(const char *input, char *output, size_t out_sz) {
+    if (!output || out_sz == 0)
+        return -1;
+    int rc = sys_ai_process(input, input ? strlen(input) : 0, output, out_sz);
+    if (rc < 0)
+        output[0] = '\0';
+    else
+        output[out_sz - 1] = '\0';
+    return rc;
+}

--- a/subsystems/ai/ai.h
+++ b/subsystems/ai/ai.h
@@ -9,6 +9,7 @@
 void ai_init(const char *profile);
 const char *ai_reply(const char *prompt);
 void ai_shutdown(void);
+int ai_process(const char *input, char *output, size_t out_sz);
 
 int ai_infer(const char *prompt, char *out, unsigned long outsz);
 


### PR DESCRIPTION
## Summary
- add SYS_AI_INIT and SYS_AI_PROCESS syscall IDs
- implement sys_ai_init and sys_ai_process wrappers
- call SYS_AI_INIT from `ai_init`
- implement `ai_process` using SYS_AI_PROCESS
- stub host-side handlers for the new syscalls

## Testing
- `pre-commit run --all-files` *(fails: eslint could not parse package.json)*
- `make test-unit`
- `pytest -q tests/python` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6852aa5d1c808325b9e4bbb059569ed1