### PR TITLE
Fix syscall ID consolidation

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -12,21 +12,32 @@
 #define IPC_RING_SIZE 64
 #define IPC_PHYS_ADDR 0x00F00000 /* physical address of shared page */
 
-/* Enumeration of syscall identifiers */
-/* Enumeration of syscall identifiers used by the host and kernel */
+/* Consolidated syscall identifiers used by host and kernel */
 typedef enum {
     SYS_NONE = 0,
-    SYS_FORK_BRANCH,   /* fork a new branch from int_arg0 -> str_arg0 */
-    SYS_MERGE_BRANCH,  /* merge branch int_arg0 into int_arg1 */
-    SYS_DELETE_BRANCH, /* delete branch identified by int_arg0 */
-    SYS_LIST_BRANCH,   /* list all branches */
-    SYS_AI_QUERY,      /* str_arg0 holds the prompt */
-    SYS_AI_MODEL_INFO, /* request model metadata */
-    SYS_FS_OPEN,       /* open file str_arg0 with mode str_arg1 */
-    SYS_FS_READ,       /* read int_arg1 bytes from fd int_arg0 */
-    SYS_FS_WRITE,      /* write int_arg1 bytes from str_arg0 to fd int_arg0 */
-    SYS_FS_CLOSE,      /* close fd in int_arg0 */
-    SYS_FS_LIST,       /* list directory str_arg0 */
+
+    /* Branch management */
+    SYS_CREATE_BRANCH,
+    SYS_MERGE_BRANCH,
+    SYS_LIST_BRANCHES,
+    SYS_SNAPSHOT_BRANCH,
+    SYS_DELETE_BRANCH,
+
+    /* Legacy/experimental */
+    SYS_FORK_BRANCH,
+    SYS_LIST_BRANCH,
+
+    /* AI requests */
+    SYS_AI_QUERY,
+    SYS_AI_MODEL_INFO,
+
+    /* Filesystem operations */
+    SYS_FS_OPEN,
+    SYS_FS_READ,
+    SYS_FS_WRITE,
+    SYS_FS_CLOSE,
+    SYS_FS_LIST,
+
     SYS_MAX
 } SyscallID;
 

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -6,6 +6,7 @@
 #include "syscall.h"
 #include "branch.h"
 #include "syscalls.h"
+#include "ipc.h"
 #include <string.h>
 #include <unistd.h>
 

--- a/tests/branch_ipc.c
+++ b/tests/branch_ipc.c
@@ -4,7 +4,7 @@
  * Purpose: Source file.
  */
 #include "ipc_host.h"
-#include "syscalls.h"
+#include "ipc.h"
 #include <assert.h>
 #include <pthread.h>
 #include <string.h>

--- a/tests/ipc_host_integration.c
+++ b/tests/ipc_host_integration.c
@@ -5,7 +5,7 @@
  */
 #include "ipc_host.h"
 #include "ipc_protocol.h"
-#include "syscalls.h"
+#include "ipc.h"
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
## Summary
- consolidate all SYS_* IDs into `ipc.h`
- remove legacy include usage in tests
- include `ipc.h` wherever syscall constants are referenced

## Testing
- `make test` *(fails: missing cross-compilation headers)*

------
https://chatgpt.com/codex/tasks/task_e_6852aa73949c8325b6a396fbbd7a6528